### PR TITLE
Spatial Join Optimization

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "magellan"
 
-version := "1.0.1"
+version := "1.0.2"
 
 organization := "harsha2010"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "magellan"
 
-version := "1.0.2"
+version := "1.0.3"
 
 organization := "harsha2010"
 

--- a/python/magellan/types.py
+++ b/python/magellan/types.py
@@ -16,14 +16,11 @@
 
 import sys
 
-from shapely.geometry import Point as SPoint
-from shapely.geometry import Polygon as SPolygon
-from shapely.geometry import LineString, MultiLineString
 from itertools import izip
 from pyspark.sql.types import UserDefinedType, StructField, StructType, \
     ArrayType, DoubleType, IntegerType
 
-__all__ = ['Point', 'Polygon']
+__all__ = ['Point', 'Polygon', 'PolyLine']
 
 class ShapelyGeometry(object):
 
@@ -113,6 +110,9 @@ class Point(ShapelyGeometry):
     >>> v = Point(1.0, 2.0)
     Point([1.0, 2.0])
     """
+
+    __UDT__ = PointUDT()
+
     def __init__(self, x, y):
         self._shape_type = 1
         self.x = x
@@ -131,6 +131,8 @@ class Point(ShapelyGeometry):
         return (Point, (self.x, self.y))
 
     def toShapely(self):
+        from shapely.geometry import Point as SPoint
+
         return SPoint(self.x, self.y)
 
 
@@ -224,6 +226,8 @@ class Polygon(ShapelyGeometry):
     Point([-1.0,-1.0, 1.0, 1.0], [0], Point(1.0, 1.0), Point(1.0, -1.0), Point(1.0, 1.0))
     """
 
+    __UDT__ = PolygonUDT()
+
     def __init__(self, indices = [], points = []):
         self._shape_type = 5
         self.indices = indices
@@ -238,6 +242,8 @@ class Polygon(ShapelyGeometry):
         return self.__str__()
 
     def toShapely(self):
+        from shapely.geometry import Polygon as SPolygon
+
         l = []
         l.extend(self.indices)
         l.append(len(self.points))
@@ -336,6 +342,8 @@ class PolyLine(ShapelyGeometry):
     Point([0], Point(1.0, 1.0), Point(1.0, -1.0), Point(1.0, 0.0))
     """
 
+    __UDT__ = PolyLineUDT()
+
     def __init__(self, indices = [], points = []):
         self._shape_type = 3
         self.indices = indices
@@ -350,6 +358,8 @@ class PolyLine(ShapelyGeometry):
         return self.__str__()
 
     def toShapely(self):
+        from shapely.geometry import LineString, MultiLineString
+
         l = []
         l.extend(self.indices)
         l.append(len(self.points))

--- a/src/main/scala/magellan/Line.scala
+++ b/src/main/scala/magellan/Line.scala
@@ -68,11 +68,8 @@ class LineUDT extends UserDefinedType[Line] {
 
   override def sqlType: DataType = Line.EMPTY
 
-  override def serialize(obj: Any): Row = {
-    val row = new GenericMutableRow(1)
-    val line = obj.asInstanceOf[Line]
-    row(0) = line
-    row
+  override def serialize(obj: Any): Line = {
+    obj.asInstanceOf[Line]
   }
 
   override def userClass: Class[Line] = classOf[Line]

--- a/src/main/scala/magellan/Line.scala
+++ b/src/main/scala/magellan/Line.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.types._
  * @param end
  */
 @SQLUserDefinedType(udt = classOf[LineUDT])
-class Line(val start: Point, val end: Point) extends Serializable with Shape {
+class Line(val start: Point, val end: Point) extends Shape {
 
   override val shapeType: Int = 2
 
@@ -66,21 +66,12 @@ class Line(val start: Point, val end: Point) extends Serializable with Shape {
 
 class LineUDT extends UserDefinedType[Line] {
 
-  private val pointDataType = new PointUDT().sqlType
-
-  override def sqlType: DataType = {
-    StructType(Seq(
-      StructField("type", IntegerType, nullable = false),
-      StructField("start", pointDataType, nullable = true),
-      StructField("end", pointDataType, nullable = true)))
-  }
+  override def sqlType: DataType = Line.EMPTY
 
   override def serialize(obj: Any): Row = {
-    val row = new GenericMutableRow(7)
+    val row = new GenericMutableRow(1)
     val line = obj.asInstanceOf[Line]
-    row(0) = line.shapeType
-    row(1) = line.start
-    row(2) = line.end
+    row(0) = line
     row
   }
 
@@ -89,11 +80,7 @@ class LineUDT extends UserDefinedType[Line] {
   override def deserialize(datum: Any): Line = {
     datum match {
       case x: Line => x
-      case r: Row => {
-        val start = r(1).asInstanceOf[Point]
-        val end = r(2).asInstanceOf[Point]
-        new Line(start, end)
-      }
+      case r: Row => r(0).asInstanceOf[Line]
       case null => null
       case _ => ???
     }
@@ -104,6 +91,8 @@ class LineUDT extends UserDefinedType[Line] {
 }
 
 private[magellan] object Line {
+
+  val EMPTY = new Line(Point.EMPTY, Point.EMPTY)
 
   def fromESRI(esriLine: ESRILine): Line = {
     val start = Point.fromESRI(esriLine.getPoint(0))

--- a/src/main/scala/magellan/MagellanContext.scala
+++ b/src/main/scala/magellan/MagellanContext.scala
@@ -18,10 +18,8 @@ package org.apache.spark.sql.magellan
 
 import org.apache.spark.SparkContext
 import org.apache.spark.api.java.JavaSparkContext
-import org.apache.spark.sql.execution.joins.BroadcastCartesianJoin
 import org.apache.spark.sql.sources.DataSourceStrategy
 import org.apache.spark.sql.{SQLConf, SQLContext, Strategy}
-import org.apache.spark.sql.magellan.execution.MagellanStrategies
 
 class MagellanContext(sc: SparkContext) extends SQLContext(sc) {
   self =>

--- a/src/main/scala/magellan/MagellanContext.scala
+++ b/src/main/scala/magellan/MagellanContext.scala
@@ -18,6 +18,8 @@ package org.apache.spark.sql.magellan
 
 import org.apache.spark.SparkContext
 import org.apache.spark.api.java.JavaSparkContext
+import org.apache.spark.sql.execution.joins.BroadcastCartesianJoin
+import org.apache.spark.sql.sources.DataSourceStrategy
 import org.apache.spark.sql.{SQLConf, SQLContext, Strategy}
 import org.apache.spark.sql.magellan.execution.MagellanStrategies
 
@@ -30,7 +32,20 @@ class MagellanContext(sc: SparkContext) extends SQLContext(sc) {
 
   @transient
   private val magellanPlanner = new SparkPlanner with MagellanStrategies {
-    override val strategies: Seq[Strategy] = Seq(SpatialJoin) ++ super.strategies
+    override val strategies: Seq[Strategy] =
+      experimental.extraStrategies ++ (
+        DataSourceStrategy ::
+        DDLStrategy ::
+        TakeOrdered ::
+        HashAggregation ::
+        LeftSemiJoin ::
+        HashJoin ::
+        InMemoryScans ::
+        ParquetOperations ::
+        BasicOperators ::
+        BroadcastCartesianJoin ::
+        CartesianProduct ::
+        BroadcastNestedLoopJoin :: Nil)
   }
 
   @transient

--- a/src/main/scala/magellan/Point.scala
+++ b/src/main/scala/magellan/Point.scala
@@ -20,6 +20,8 @@ import com.esri.core.geometry.{Point => ESRIPoint}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.GenericMutableRow
 import org.apache.spark.sql.types._
+import org.json4s.JsonAST.JValue
+import org.json4s.JsonDSL._
 
 /**
  * A point is a zero dimensional shape.
@@ -31,6 +33,8 @@ import org.apache.spark.sql.types._
  */
 @SQLUserDefinedType(udt = classOf[PointUDT])
 class Point(val x: Double, val y: Double) extends Shape {
+
+  def this() {this(0.0, 0.0)}
 
   override private[magellan] val delegate = {
     val p = new ESRIPoint()
@@ -70,19 +74,24 @@ class Point(val x: Double, val y: Double) extends Shape {
    */
   override def transform(fn: (Point) => Point): Point = fn(this)
 
+  override def jsonValue: JValue =
+    ("type" -> "udt") ~
+      ("class" -> this.getClass.getName) ~
+      ("pyClass" -> "magellan.types.PointUDT") ~
+      ("x" -> x) ~
+      ("y" -> y)
 }
 
 private[magellan] class PointUDT extends UserDefinedType[Point] {
 
   override def sqlType: DataType = Point.EMPTY
 
-  override def serialize(obj: Any): Row = {
-    val row = new GenericMutableRow(1)
+  override def serialize(obj: Any): Point = {
     obj match {
-      case p: Point => row(0) = p
+      case p: Point => p
+      case Array(t: Int, x: Double, y: Double) => new Point(x, y)
       case _ => ???
     }
-    row
   }
 
   override def userClass: Class[Point] = classOf[Point]
@@ -95,6 +104,7 @@ private[magellan] class PointUDT extends UserDefinedType[Point] {
       // TODO: There is a bug in UDT serialization in Spark.This should never happen.
       case p: Point => p
       case null => null
+      case Array(t: Int, x: Double, y: Double) => Point(x, y)
       case _ => ???
     }
   }
@@ -105,7 +115,7 @@ private[magellan] class PointUDT extends UserDefinedType[Point] {
 
 object Point {
 
-  val EMPTY = new Point(0.0, 0.0)
+  val EMPTY = new Point()
 
   private[magellan] def fromESRI(esriPoint: ESRIPoint): Point = {
     new Point(esriPoint.getX(), esriPoint.getY())

--- a/src/main/scala/magellan/Point.scala
+++ b/src/main/scala/magellan/Point.scala
@@ -74,17 +74,12 @@ class Point(val x: Double, val y: Double) extends Shape {
 
 private[magellan] class PointUDT extends UserDefinedType[Point] {
 
-  override def sqlType: DataType = {
-    StructType(Seq(
-      StructField("type", IntegerType, nullable = false),
-      StructField("x", DoubleType, nullable = true),
-      StructField("y", DoubleType, nullable = true)))
-  }
+  override def sqlType: DataType = Point.EMPTY
 
   override def serialize(obj: Any): Row = {
-    val row = new GenericMutableRow(3)
+    val row = new GenericMutableRow(1)
     obj match {
-      case p: Point => row(0) = p.shapeType; row(1) = p.x; row(2) = p.y
+      case p: Point => row(0) = p
       case _ => ???
     }
     row
@@ -95,11 +90,7 @@ private[magellan] class PointUDT extends UserDefinedType[Point] {
   override def deserialize(datum: Any): Point = {
     datum match {
       case row: Row => {
-        val t = row(0)
-        t match {
-          case 1 => new Point(row.getDouble(1), row.getDouble(2))
-          case _ => ???
-        }
+        row(0).asInstanceOf[Point]
       }
       // TODO: There is a bug in UDT serialization in Spark.This should never happen.
       case p: Point => p
@@ -113,6 +104,8 @@ private[magellan] class PointUDT extends UserDefinedType[Point] {
 }
 
 object Point {
+
+  val EMPTY = new Point(0.0, 0.0)
 
   private[magellan] def fromESRI(esriPoint: ESRIPoint): Point = {
     new Point(esriPoint.getX(), esriPoint.getY())

--- a/src/main/scala/magellan/Shape.scala
+++ b/src/main/scala/magellan/Shape.scala
@@ -26,12 +26,15 @@ import org.apache.spark.sql.types._
 /**
  * An abstraction for a geometric shape.
  */
-trait Shape extends Serializable {
+trait Shape extends DataType with Serializable {
 
   val shapeType: Int
 
   private[magellan] val delegate: ESRIGeometry
-  @transient private var factory = OperatorFactoryLocal.getInstance
+
+  override def defaultSize: Int = 4096
+
+  override def asNullable: DataType = this
 
   /**
    * Applies an arbitrary point wise transformation to a given shape.
@@ -92,6 +95,7 @@ trait Shape extends Serializable {
    * @see Shape#disjoint
    */
   def intersects(other: Shape, bitMask: Int): Boolean = {
+    val factory = OperatorFactoryLocal.getInstance
     val op = factory.getOperator(Operator.Type.Intersection).asInstanceOf[OperatorIntersection]
     val result_cursor = op.execute(new SimpleGeometryCursor(
       delegate), new SimpleGeometryCursor(other.delegate), null, null, bitMask)
@@ -187,6 +191,7 @@ trait Shape extends Serializable {
    * @return a Shape representing the point-set common to the two <code>Shape</code>s
    */
   def intersection(other: Shape): Shape = {
+    val factory = OperatorFactoryLocal.getInstance
     val op = factory.getOperator(Operator.Type.Intersection).asInstanceOf[OperatorIntersection]
     val result_cursor = op.execute(new SimpleGeometryCursor(
       delegate), new SimpleGeometryCursor(other.delegate), null, null, 7)
@@ -234,9 +239,6 @@ trait Shape extends Serializable {
     ???
   }
 
-  private def readObject(is: ObjectInputStream): Unit = {
-    factory = OperatorFactoryLocal.getInstance
-  }
 }
 
 /**
@@ -258,18 +260,10 @@ object NullShape extends Shape {
 
 private[magellan] object Shape {
 
-  val TYPES = Map[Int, UserDefinedType[_ <: Shape]](
-      1 -> new PointUDT,
-      2 -> new LineUDT,
-      3 -> new PolyLineUDT,
-      5 -> new PolygonUDT
-    )
-
   def deserialize(obj: Any): Shape = {
     obj match {
       case s: Shape => s
-      case row: Row =>
-        TYPES.get(toInt(row, 0)).fold[Shape](NullShape)(_.deserialize(row))
+      case row: Row => row(0).asInstanceOf[Shape]
     }
   }
 

--- a/src/main/scala/magellan/Shape.scala
+++ b/src/main/scala/magellan/Shape.scala
@@ -281,11 +281,4 @@ private[magellan] object Shape {
       case _ => ???
     }
   }
-
-  private def toInt(row: Row, index: Int): Int = {
-    row(index) match {
-      case i: Int => i
-      case i: Long => i.toInt
-    }
-  }
 }

--- a/src/main/scala/magellan/Shape.scala
+++ b/src/main/scala/magellan/Shape.scala
@@ -260,13 +260,6 @@ object NullShape extends Shape {
 
 private[magellan] object Shape {
 
-  def deserialize(obj: Any): Shape = {
-    obj match {
-      case s: Shape => s
-      case row: Row => row(0).asInstanceOf[Shape]
-    }
-  }
-
   def fromESRI(esriGeom: ESRIGeometry): Shape = {
     esriGeom match {
       case esriPoint: ESRIPoint => Point.fromESRI(esriPoint)

--- a/src/main/scala/magellan/catalyst/ShapeLiteral.scala
+++ b/src/main/scala/magellan/catalyst/ShapeLiteral.scala
@@ -31,6 +31,6 @@ case class ShapeLiteral(shape: Shape) extends LeafExpression {
 
   override def eval(input: Row): Shape = shape
 
-  override val dataType: DataType = Shape.TYPES(shape.shapeType)
+  override val dataType: DataType = shape
 
 }

--- a/src/main/scala/magellan/catalyst/Transformer.scala
+++ b/src/main/scala/magellan/catalyst/Transformer.scala
@@ -29,8 +29,7 @@ case class Transformer(
   override type EvaluatedType = child.EvaluatedType
 
   override def eval(input: Row): EvaluatedType = {
-    val row = child.eval(input).asInstanceOf[Row]
-    val shape = Shape.deserialize(row)
+    val shape = child.eval(input).asInstanceOf[Shape]
     shape.transform(fn).asInstanceOf[EvaluatedType]
   }
 
@@ -42,8 +41,7 @@ case class Transformer(
     if (input == null) {
       null
     } else {
-      val row = input.asInstanceOf[Row]
-      val shape = Shape.deserialize(row)
+      val shape = input.asInstanceOf[Shape]
       shape.transform(fn)
     }
   }

--- a/src/main/scala/magellan/catalyst/expressions.scala
+++ b/src/main/scala/magellan/catalyst/expressions.scala
@@ -43,8 +43,8 @@ case class Intersection(left: Expression, right: Expression)
       NullShape
     } else {
       val rightEval = right.eval(input)
-      val leftShape = Shape.deserialize(leftEval)
-      val rightShape = Shape.deserialize(rightEval)
+      val leftShape = leftEval.asInstanceOf[Shape]
+      val rightShape = rightEval.asInstanceOf[Shape]
       if (rightEval == null) NullShape else leftShape.intersection(rightShape)
     }
   }
@@ -52,11 +52,11 @@ case class Intersection(left: Expression, right: Expression)
   override def nullable: Boolean = left.nullable || right.nullable
 
   protected def nullSafeEval(input1: Any, input2: Any): Any = {
-    val leftShape = Shape.deserialize(input1)
+    val leftShape = input1.asInstanceOf[Shape]
     if (leftShape == null) {
       null
     } else {
-      val rightShape = Shape.deserialize(input2)
+      val rightShape = input2.asInstanceOf[Shape]
       if (rightShape == null) null else rightShape.intersection(leftShape)
     }
   }

--- a/src/main/scala/magellan/catalyst/predicates.scala
+++ b/src/main/scala/magellan/catalyst/predicates.scala
@@ -41,8 +41,8 @@ case class Within(left: Expression, right: Expression)
       null
     } else {
       val rightEval = right.eval(input)
-      val leftShape = Shape.deserialize(leftEval)
-      val rightShape = Shape.deserialize(rightEval)
+      val leftShape = leftEval.asInstanceOf[Shape]
+      val rightShape = rightEval.asInstanceOf[Shape]
       if (rightEval == null) null else rightShape.contains(leftShape)
     }
   }
@@ -50,11 +50,11 @@ case class Within(left: Expression, right: Expression)
   override def nullable: Boolean = left.nullable || right.nullable
 
   protected def nullSafeEval(input1: Any, input2: Any): Any = {
-    val leftShape = Shape.deserialize(input1)
+    val leftShape = input1.asInstanceOf[Shape]
     if (leftShape == null) {
       null
     } else {
-      val rightShape = Shape.deserialize(input2)
+      val rightShape = input2.asInstanceOf[Shape]
       if (rightShape == null) null else rightShape.contains(leftShape)
     }
   }
@@ -82,8 +82,8 @@ case class Intersects(left: Expression, right: Expression)
       false
     } else {
       val rightEval = right.eval(input)
-      val leftShape = Shape.deserialize(leftEval)
-      val rightShape = Shape.deserialize(rightEval)
+      val leftShape = leftEval.asInstanceOf[Shape]
+      val rightShape = rightEval.asInstanceOf[Shape]
       if (rightEval == null) false else leftShape.intersects(rightShape)
     }
   }
@@ -91,11 +91,11 @@ case class Intersects(left: Expression, right: Expression)
   override def nullable: Boolean = left.nullable || right.nullable
 
   protected def nullSafeEval(input1: Any, input2: Any): Any = {
-    val leftShape = Shape.deserialize(input1)
+    val leftShape = input1.asInstanceOf[Shape]
     if (leftShape == null) {
       null
     } else {
-      val rightShape = Shape.deserialize(input2)
+      val rightShape = input2.asInstanceOf[Shape]
       if (rightShape == null) null else rightShape.intersects(leftShape)
     }
   }

--- a/src/main/scala/magellan/execution/BroadcastCartesianJoin.scala
+++ b/src/main/scala/magellan/execution/BroadcastCartesianJoin.scala
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2015 Ram Sriharsha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.joins
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.execution.{BinaryNode, SparkPlan}
+import org.apache.spark.util.collection.CompactBuffer
+
+case class BroadcastCartesianJoin(
+    left: SparkPlan,
+    right: SparkPlan,
+    buildSide: BuildSide,
+    condition: Option[Expression]) extends BinaryNode {
+
+  /** BuildRight means the right relation <=> the broadcast relation. */
+  private val (streamed, broadcast) = buildSide match {
+    case BuildRight => (left, right)
+    case BuildLeft => (right, left)
+  }
+
+  @transient private lazy val boundCondition =
+    newPredicate(condition.getOrElse(Literal(true)), left.output ++ right.output)
+
+  override protected def doExecute(): RDD[Row] = {
+    val bc = broadcast.execute()
+    val broadcastedRelation = sparkContext.broadcast(bc.map(_.copy()).collect().toIndexedSeq)
+
+    streamed.execute().mapPartitions { streamedIter =>
+      val v = broadcastedRelation.value
+      val matchedRows = new CompactBuffer[Row]
+      val joinedRow = new JoinedRow
+
+      streamedIter.foreach { streamedRow =>
+        var i = 0
+
+        while (i < v.size) {
+          // TODO: One bitset per partition instead of per row.
+          val broadcastedRow = v(i)
+          buildSide match {
+            case BuildRight if boundCondition(joinedRow(streamedRow, broadcastedRow)) =>
+              matchedRows += joinedRow(streamedRow, broadcastedRow).copy()
+            case BuildLeft if boundCondition(joinedRow(broadcastedRow, streamedRow)) =>
+              matchedRows += joinedRow(broadcastedRow, streamedRow).copy()
+            case _ =>
+          }
+          i += 1
+        }
+
+      }
+      matchedRows.iterator
+    }
+
+  }
+
+  override def output: Seq[Attribute] = left.output ++ right.output
+
+}

--- a/src/main/scala/magellan/execution/MagellanStrategies.scala
+++ b/src/main/scala/magellan/execution/MagellanStrategies.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.magellan.execution
+package org.apache.spark.sql.magellan
 
 import org.apache.spark.annotation.Experimental
-import org.apache.spark.sql.catalyst.plans.{Inner, logical}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.execution.{joins, SparkPlan, Filter}
+import org.apache.spark.sql.catalyst.plans.{Inner, logical}
+import org.apache.spark.sql.execution.{Filter, SparkPlan, joins}
 import org.apache.spark.sql.{SQLContext, Strategy}
 
 trait MagellanStrategies {

--- a/src/main/scala/magellan/execution/MagellanStrategies.scala
+++ b/src/main/scala/magellan/execution/MagellanStrategies.scala
@@ -36,12 +36,9 @@ trait MagellanStrategies {
           } else {
             joins.BuildLeft
           }
-        val j = joins.BroadcastCartesianJoin(
+        val broadcastCartesianJoin = joins.BroadcastCartesianJoin(
           planLater(left), planLater(right), buildSide, condition)
-        condition match {
-          case Some(c) => Filter(c, j) :: Nil
-          case None => j :: Nil
-        }
+        condition.map(Filter(_, broadcastCartesianJoin)).getOrElse(broadcastCartesianJoin) :: Nil
 
       case _ => Nil
     }

--- a/src/main/scala/magellan/execution/pythonUDFs.scala
+++ b/src/main/scala/magellan/execution/pythonUDFs.scala
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2015 Ram Sriharsha
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.magellan
+
+import java.io.OutputStream
+import java.util.{List => JList}
+
+import scala.collection.JavaConversions._
+
+import magellan.{PolyLine, Point, Polygon, Shape}
+import net.razorvine.pickle._
+import org.apache.spark.sql.catalyst.expressions._
+
+object EvaluatePython {
+
+  private val pysparkModule = "pyspark.sql.types"
+
+  private val magellanModule = "magellan.types"
+
+  /**
+   * Pickler for Shape
+   */
+  private class ShapePickler extends IObjectPickler {
+
+    def register(): Unit = {
+      Pickler.registerCustomPickler(classOf[Point], this)
+      Pickler.registerCustomPickler(classOf[Polygon], this)
+      Pickler.registerCustomPickler(classOf[PolyLine], this)
+    }
+
+    def pickle(obj: Object, out: OutputStream, pickler: Pickler): Unit = {
+      out.write(Opcodes.GLOBAL)
+      out.write((magellanModule + "\n" + "_inbound_shape_converter" + "\n").getBytes("utf-8"))
+      val point = obj.asInstanceOf[Shape]
+      pickler.save(point.json)
+      out.write(Opcodes.TUPLE1)
+      out.write(Opcodes.REDUCE)
+    }
+  }
+
+  private class PointUnpickler extends IObjectConstructor {
+
+    def register(): Unit = {
+      Unpickler.registerConstructor("magellan.types", "Point", this)
+    }
+
+    override def construct(args: Array[AnyRef]): AnyRef = {
+      require(args.length == 2)
+      val x = args(0).asInstanceOf[Double]
+      val y = args(1).asInstanceOf[Double]
+      new Point(x, y)
+    }
+  }
+
+  private class PolygonUnpickler extends IObjectConstructor {
+
+    def register(): Unit = {
+      Unpickler.registerConstructor("magellan.types", "Polygon", this)
+    }
+
+    override def construct(args: Array[AnyRef]): AnyRef = {
+      val indices = args(0).asInstanceOf[JList[Int]]
+      val points = args(1).asInstanceOf[JList[Point]]
+      new Polygon(indices.toIndexedSeq, points.toIndexedSeq)
+    }
+  }
+
+  private class PolyLineUnpickler extends IObjectConstructor {
+
+    def register(): Unit = {
+      Unpickler.registerConstructor("magellan.types", "PolyLine", this)
+    }
+
+    override def construct(args: Array[AnyRef]): AnyRef = {
+      val indices = args(0).asInstanceOf[JList[Int]]
+      val points = args(1).asInstanceOf[JList[Point]]
+      new PolyLine(indices.toIndexedSeq, points.toIndexedSeq)
+    }
+  }
+
+  /**
+   * Pickler for InternalRow
+   */
+  private class RowPickler extends IObjectPickler {
+
+    private val cls = classOf[GenericMutableRow]
+
+    // register this to Pickler and Unpickler
+    def register(): Unit = {
+      Pickler.registerCustomPickler(this.getClass, this)
+      Pickler.registerCustomPickler(cls, this)
+    }
+
+    def pickle(obj: Object, out: OutputStream, pickler: Pickler): Unit = {
+      if (obj == this) {
+        out.write(Opcodes.GLOBAL)
+        out.write((magellanModule + "\n" + "_create_row_inbound_converter" + "\n").getBytes("utf-8"))
+      } else {
+        // it will be memorized by Pickler to save some bytes
+        pickler.save(this)
+        val row = obj.asInstanceOf[GenericMutableRow]
+        // schema should always be same object for memoization
+        pickler.save(row.schema)
+        out.write(Opcodes.TUPLE1)
+        out.write(Opcodes.REDUCE)
+        out.write(Opcodes.MARK)
+        var i = 0
+        while (i < row.size) {
+          val v = row.get(i)
+          pickler.save(v)
+          i += 1
+        }
+        out.write(Opcodes.TUPLE)
+        out.write(Opcodes.REDUCE)
+      }
+    }
+  }
+
+  private[this] var registered = false
+  /**
+   * This should be called before trying to serialize any above classes un cluster mode,
+   * this should be put in the closure
+   */
+  def registerPicklers(): Unit = {
+    synchronized {
+      if (!registered) {
+        new ShapePickler().register()
+        new RowPickler().register()
+        new PointUnpickler().register()
+        new PolygonUnpickler().register()
+        new PolyLineUnpickler().register()
+        registered = true
+      }
+    }
+  }
+}


### PR DESCRIPTION
1. Use Broadcast Cartesian Join (eventually replace with Spatial indices?)
2. Avoid type serialization by defining geometric data structures directly as Data Types in Spark SQL.