### PR TITLE
Test against multiple Spark and Hadoop versions in Travis; fix Hadoop 1.x incompatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,23 +19,10 @@ matrix:
     - jdk: openjdk7
       scala: 2.10.5
       env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.4.1"
-    # Spark 1.5.1 tests (1.5+ only supports Java 7+):
-    - jdk: openjdk7
-      scala: 2.10.5
-      env: TEST_HADOOP_VERSION="1.0.4" TEST_SPARK_VERSION="1.5.1"
-    - jdk: openjdk7
-      scala: 2.10.5
-      env: TEST_HADOOP_VERSION="1.2.1" TEST_SPARK_VERSION="1.5.1"
-    - jdk: openjdk7
-      scala: 2.10.5
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.5.1"
     # Scala 2.11 tests:
     - jdk: openjdk7
       scala: 2.11.7
       env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.4.1"
-    - jdk: openjdk7
-      scala: 2.11.7
-      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.5.1"
 script:
   - sbt -Dhadoop.testVersion=$TEST_HADOOP_VERSION -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,42 @@
 language: scala
-scala:
-  - 2.10.4
-jdk:
-  - openjdk7
-  - openjdk6
 sudo: false
+cache:
+  directories:
+    - $HOME/.ivy2
+# There's no nicer way to specify this matrix; see
+# https://github.com/travis-ci/travis-ci/issues/1519.
+matrix:
+  include:
+    - jdk: openjdk6
+      scala: 2.10.5
+      env: TEST_HADOOP_VERSION="1.0.4" TEST_SPARK_VERSION="1.4.1"
+    - jdk: openjdk6
+      scala: 2.10.5
+      env: TEST_HADOOP_VERSION="1.2.1" TEST_SPARK_VERSION="1.4.1"
+    - jdk: openjdk6
+      scala: 2.10.5
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.4.1"
+    - jdk: openjdk7
+      scala: 2.10.5
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.4.1"
+    # Spark 1.5.1 tests (1.5+ only supports Java 7+):
+    - jdk: openjdk7
+      scala: 2.10.5
+      env: TEST_HADOOP_VERSION="1.0.4" TEST_SPARK_VERSION="1.5.1"
+    - jdk: openjdk7
+      scala: 2.10.5
+      env: TEST_HADOOP_VERSION="1.2.1" TEST_SPARK_VERSION="1.5.1"
+    - jdk: openjdk7
+      scala: 2.10.5
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.5.1"
+    # Scala 2.11 tests:
+    - jdk: openjdk7
+      scala: 2.11.7
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.4.1"
+    - jdk: openjdk7
+      scala: 2.11.7
+      env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="1.5.1"
 script:
-  - sbt -jvm-opts travis/jvmopts.compile compile
-  - sbt -jvm-opts travis/jvmopts.test coverage test
+  - sbt -Dhadoop.testVersion=$TEST_HADOOP_VERSION -Dspark.testVersion=$TEST_SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalaVersion := "2.10.4"
 
 crossScalaVersions := Seq("2.10.5", "2.11.7")
 
-sparkVersion := "1.4.0"
+sparkVersion := "1.4.1"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,26 +1,41 @@
 name := "magellan"
 
-version := "1.0.3"
+version := "1.0.3-SNAPSHOT"
 
 organization := "harsha2010"
 
 scalaVersion := "2.10.4"
 
-parallelExecution in Test := false
+crossScalaVersions := Seq("2.10.5", "2.11.7")
 
-crossScalaVersions := Seq("2.10.4", "2.11.6")
+sparkVersion := "1.4.0"
 
-libraryDependencies += "commons-io" % "commons-io" % "2.4"
+val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 
-libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.5" % "provided"
+testSparkVersion := sys.props.get("spark.testVersion").getOrElse(sparkVersion.value)
 
-libraryDependencies += "com.esri.geometry" % "esri-geometry-api" % "1.2.1"
+val testHadoopVersion = settingKey[String]("The version of Hadoop to test against.")
 
-resolvers ++= Seq(
-  "Apache Staging" at "https://repository.apache.org/content/repositories/staging/",
-  "Typesafe" at "http://repo.typesafe.com/typesafe/releases",
-  "Local Maven Repository" at "file://"+Path.userHome.absolutePath+"/.m2/repository"
+testHadoopVersion := sys.props.getOrElse("hadoop.testVersion", "2.2.0")
+
+sparkComponents := Seq("core", "sql")
+
+libraryDependencies ++= Seq(
+  "commons-io" % "commons-io" % "2.4",
+  "org.slf4j" % "slf4j-api" % "1.7.5" % "provided",
+  "com.esri.geometry" % "esri-geometry-api" % "1.2.1",
+  "org.scalatest" %% "scalatest" % "2.2.1" % "test"
 )
+
+libraryDependencies ++= Seq(
+  "org.apache.hadoop" % "hadoop-client" % testHadoopVersion.value % "test",
+  "org.apache.spark" %% "spark-core" % testSparkVersion.value % "test" exclude("org.apache.hadoop", "hadoop-client"),
+  "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "test" exclude("org.apache.hadoop", "hadoop-client")
+)
+
+// This is necessary because of how we explicitly specify Spark dependencies
+// for tests rather than using the sbt-spark-package plugin to provide them.
+spIgnoreProvided := true
 
 publishMavenStyle := true
 
@@ -59,19 +74,13 @@ pomExtra := (
 
 spName := "harsha2010/magellan"
 
-sparkVersion := "1.4.0"
-
-sparkComponents += "sql"
-
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.1" % "test"
-
-libraryDependencies += "com.novocode" % "junit-interface" % "0.9" % "test"
+parallelExecution in Test := false
 
 ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := {
   if (scalaBinaryVersion.value == "2.10") false
-  else false
+  else true
 }
 
 credentials += Credentials(Path.userHome / ".ivy2" / ".sbtcredentials")
 
-licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0") 
+licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.12.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")

--- a/project/build.properties
+++ b/project/build.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=0.13.6
+sbt.version=0.13.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,38 +1,23 @@
-scalaVersion := "2.10.4"
-
-resolvers += Resolver.url("artifactory", url("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
-
-resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
-
-resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"
-
 resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages/maven"
 
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0")
 
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 
-addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.1")
+addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.2")
 
-// For Sonatype publishing
-//resolvers += Resolver.url("sbt-plugin-releases", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.5")
 
-//addSbtPlugin("com.jsuereth" % "xsbt-gpg-plugin" % "0.6")
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
-
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.1.0")
-
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.6")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.7.0" excludeAll(
+  ExclusionRule(organization = "com.danieltrinh")))
+libraryDependencies += "org.scalariform" %% "scalariform" % "0.1.7"
 
 addSbtPlugin("com.alpinenow" % "junit_xml_listener" % "0.5.1")
 
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.1")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
-libraryDependencies += "org.ow2.asm"  % "asm" % "5.0.3"
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.1.0")
 
-libraryDependencies += "org.ow2.asm"  % "asm-commons" % "5.0.3"
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.7")

--- a/src/main/scala/magellan/mapreduce/DBReader.scala
+++ b/src/main/scala/magellan/mapreduce/DBReader.scala
@@ -21,6 +21,7 @@ import java.io.DataInputStream
 import scala.collection.mutable.ListBuffer
 
 import org.apache.commons.io.EndianUtils
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io._
 import org.apache.hadoop.mapreduce.lib.input.FileSplit
 import org.apache.hadoop.mapreduce.{InputSplit, RecordReader, TaskAttemptContext}
@@ -108,7 +109,7 @@ private[magellan] class DBReader extends RecordReader[ShapeKey, MapWritable] {
       taskAttemptContext: TaskAttemptContext): Unit = {
 
     val split = inputSplit.asInstanceOf[FileSplit]
-    val job = taskAttemptContext.getConfiguration()
+    val job = MapReduceUtils.getConfigurationFromContext(taskAttemptContext)
     val start = split.getStart()
     val end = start + split.getLength()
     val file = split.getPath()

--- a/src/main/scala/magellan/mapreduce/MapReduceUtils.scala
+++ b/src/main/scala/magellan/mapreduce/MapReduceUtils.scala
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2015 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package magellan.mapreduce
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.mapreduce.TaskAttemptContext
+
+private[magellan] object MapReduceUtils {
+  def getConfigurationFromContext(context: TaskAttemptContext): Configuration = {
+    // Use reflection to get the Configuration. This is necessary because TaskAttemptContext
+    // is a class in Hadoop 1.x and an interface in Hadoop 2.x.
+    val method = context.getClass.getMethod("getConfiguration")
+    method.invoke(context).asInstanceOf[Configuration]
+  }
+}

--- a/src/main/scala/magellan/mapreduce/ShapefileReader.scala
+++ b/src/main/scala/magellan/mapreduce/ShapefileReader.scala
@@ -59,7 +59,7 @@ private[magellan] class ShapefileReader extends RecordReader[ShapeKey, ShapeWrit
 
   override def initialize(inputSplit: InputSplit, taskAttemptContext: TaskAttemptContext) {
     val split = inputSplit.asInstanceOf[FileSplit]
-    val job = taskAttemptContext.getConfiguration()
+    val job = MapReduceUtils.getConfigurationFromContext(taskAttemptContext)
     val start = split.getStart()
     val end = start + split.getLength()
     val file = split.getPath()

--- a/src/main/scala/magellan/mapreduce/WholeFileReader.scala
+++ b/src/main/scala/magellan/mapreduce/WholeFileReader.scala
@@ -61,7 +61,7 @@ class WholeFileReader extends RecordReader[NullWritable, Text] {
   override def initialize(inputSplit: InputSplit,
     taskAttemptContext: TaskAttemptContext): Unit = {
     this.split = inputSplit.asInstanceOf[FileSplit]
-    this.conf = taskAttemptContext.getConfiguration
+    this.conf = MapReduceUtils.getConfigurationFromContext(taskAttemptContext)
   }
 
   override def getCurrentKey: NullWritable = key


### PR DESCRIPTION
This patch modifies Magellan's build and Travis configuration in order to compile against a fixed set of Spark and Hadoop versions, then test those compiled artifacts against a range of different runtime Spark and Hadoop dependencies. This style of testing simulates how users will interact with the published Magellan binaries.

These changes are similar to ones that I've made in Databricks' own libraries: https://github.com/databricks/spark-redshift/pull/58, https://github.com/databricks/spark-csv/pull/138, https://github.com/databricks/spark-avro/pull/79.

This testing revealed a binary incompatibility when running against Hadoop 1.x, which is caused by changes in Hadoop's TaskAttemptContext class. I fixed this using reflection, similar to the fix employed in https://github.com/apache/spark/pull/6599.

I also tried testing the 1.4.1-compiled artifacts against Spark 1.5.1, but ran into the problems described in #18 and decided to remove those test configurations for now.