### PR TITLE
Fix broken sbt/sbt spDist...looks like 0.13.9 is not installing properly

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=0.13.9
+sbt.version=0.13.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,6 +10,7 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.5")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.7.0" excludeAll(
   ExclusionRule(organization = "com.danieltrinh")))
+
 libraryDependencies += "org.scalariform" %% "scalariform" % "0.1.7"
 
 addSbtPlugin("com.alpinenow" % "junit_xml_listener" % "0.5.1")


### PR DESCRIPTION
@JoshRosen I ran into an issue running sbt/sbt clean test, as well as sbt/sbt spDist which seems to be due to two things:
1. the sbt 0.13.9 jar is not getting properly downloaded
2. There is a missing next line in the plugins file.

Error: Invalid or corrupt jarfile sbt/sbt-launch-0.13.9.jar

I fixed these issues but maybe there is a better solution. Can you take a look?