### PR TITLE
Fix Coordinate Transform for Polygon/ Polyline

### DIFF
--- a/src/main/scala/magellan/PolyLine.scala
+++ b/src/main/scala/magellan/PolyLine.scala
@@ -92,7 +92,7 @@ class PolyLine(
    * @return
    */
   override def transform(fn: (Point) => Point): PolyLine = {
-    val transformedPoints = points.map(fn)
+    val transformedPoints = points.map(point => point.transform(fn))
     new PolyLine(indices, transformedPoints)
   }
 

--- a/src/main/scala/magellan/Polygon.scala
+++ b/src/main/scala/magellan/Polygon.scala
@@ -106,7 +106,7 @@ class Polygon(
    * @return
    */
   override def transform(fn: (Point) => Point): Polygon = {
-    val transformedPoints = points.map(fn)
+    val transformedPoints = points.map(point => point.transform(fn))
     new Polygon(indices, transformedPoints)
   }
 

--- a/src/test/scala/magellan/PolyLineSuite.scala
+++ b/src/test/scala/magellan/PolyLineSuite.scala
@@ -28,4 +28,14 @@ class PolyLineSuite extends FunSuite {
     assert(polyline.intersects(new Line(new Point(-1.0, -1.0), new Point(2.0, 2.0))))
     assert(polyline.intersects(new Line(new Point(-1.1, -1), new Point(1.9, 2.0))))
   }
+
+  test("transform") {
+    val polyline1 = new PolyLine(Array(0), Array(
+      new Point(0.0, 0.0), new Point(0.0, 1.0), new Point(1.0, 1.0)
+    ))
+    val polyline2 = polyline1.transform((p: Point) => new Point(3 * p.x, 3 * p.y))
+    assert(polyline2.points(0).equals(new Point(0.0, 0.0)))
+    assert(polyline2.points(2).equals(new Point(3.0, 3.0)))
+
+  }
 }

--- a/src/test/scala/magellan/PolygonSuite.scala
+++ b/src/test/scala/magellan/PolygonSuite.scala
@@ -113,4 +113,14 @@ class PolygonSuite extends FunSuite {
     val polygon4 = Polygon.fromESRI(polygon3.delegate)
     assert(polygon3.equals(polygon4))
   }
+
+  test("transform") {
+    val ring1 = Array(new Point(1.0, 1.0), new Point(1.0, -1.0),
+      new Point(-1.0, -1.0), new Point(-1.0, 1.0), new Point(1.0, 1.0))
+    val polygon1 = new Polygon(Array(0), ring1)
+    val polygon2 = polygon1.transform((x: Point) => new Point(3 * x.x, 3 * x.y))
+    assert(polygon2.points(0).equals(new Point(3.0, 3.0)))
+    assert(polygon2.points(1).equals(new Point(3.0, -3.0)))
+
+  }
 }


### PR DESCRIPTION
There was a bug in coordinate transformation rules for Polygon and Polyline which was not allowing proper scaling of shapes under coordinate transformation. This PR fixes the issue.