### PR TITLE
Fix wrong double interpretation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "magellan"
 
-version := "1.0.4"
+version := "1.0.4-SNAPSHOT"
 
 organization := "harsha2010"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "magellan"
 
-version := "1.0.4.1"
+version := "1.0.4"
 
 organization := "harsha2010"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "magellan"
 
-version := "1.0.4-SNAPSHOT"
+version := "1.0.4.1"
 
 organization := "harsha2010"
 

--- a/src/main/scala/magellan/Polygon.scala
+++ b/src/main/scala/magellan/Polygon.scala
@@ -113,7 +113,16 @@ class Polygon(
    * @param fn
    * @return
    */
-  override def transform(fn: (Point) => Point): Shape = ???
+  override def transform(fn: (Point) => Point): Shape = {
+    val transformedPoints = (xcoordinates zip ycoordinates)
+      .map { case (x, y) => Point(x, y) }
+      .map(point => point.transform(fn))
+    new Polygon(
+      indices,
+      transformedPoints.map(p => p.getX()),
+      transformedPoints.map(p => p.getY()),
+      boundingBox)
+  }
 
 
   def canEqual(other: Any): Boolean = other.isInstanceOf[Polygon]

--- a/src/main/scala/magellan/io/ShapeReader.scala
+++ b/src/main/scala/magellan/io/ShapeReader.scala
@@ -78,8 +78,8 @@ private[magellan] class PolygonReader extends ShapeReader {
     val points = ArrayBuffer[Point]()
     for (_ <- 0 until numPoints) {
       points.+= {
-        val x = EndianUtils.swapDouble(dataInput.readDouble())
-        val y = EndianUtils.swapDouble(dataInput.readDouble())
+        val x = java.lang.Double.longBitsToDouble(java.lang.Long.reverseBytes(dataInput.readLong()))
+        val y = java.lang.Double.longBitsToDouble(java.lang.Long.reverseBytes(dataInput.readLong()))
         Point(x, y)
       }
     }


### PR DESCRIPTION
We've seen strange results for one-in-a-million polygons in shape files we processed with magellan where one coordinate value was exactly 10. This was far far away from what we expected. We tracked the problem to one example value (0xFFF0A0EF35994341) being read as NaN by `EndianUtils.swapDouble(dataInput.readDouble())`. I'm not sure about the math but as defined for IEEE754 floating point numbers tested to read the bytes as long, swap them and interpret this as a double. This way all our polygons seem to be correct.