### PR TITLE
Handle more file with more than 2GB size, reimplement transform

### DIFF
--- a/src/main/scala/magellan/Polygon.scala
+++ b/src/main/scala/magellan/Polygon.scala
@@ -113,7 +113,16 @@ class Polygon(
    * @param fn
    * @return
    */
-  override def transform(fn: (Point) => Point): Shape = ???
+  override def transform(fn: (Point) => Point): Shape = {
+    val transformedPoints = (xcoordinates zip ycoordinates)
+      .map { case (x, y) => Point(x, y) }
+      .map(point => point.transform(fn))
+    new Polygon(
+      indices,
+      transformedPoints.map(p => p.getX()),
+      transformedPoints.map(p => p.getY()),
+      boundingBox)
+  }
 
 
   def canEqual(other: Any): Boolean = other.isInstanceOf[Polygon]

--- a/src/main/scala/magellan/mapreduce/ShapefileReader.scala
+++ b/src/main/scala/magellan/mapreduce/ShapefileReader.scala
@@ -32,9 +32,9 @@ private[magellan] class ShapefileReader extends RecordReader[ShapeKey, ShapeWrit
 
   private var dis: DataInputStream = _
 
-  private var length: Int = _
+  private var length: Long = _
 
-  private var remaining: Int = _
+  private var remaining: Long = _
 
   override def getProgress: Float = remaining / length.toFloat
 
@@ -70,7 +70,7 @@ private[magellan] class ShapefileReader extends RecordReader[ShapeKey, ShapeWrit
     // skip the next 20 bytes which should all be zero
     0 until 5 foreach {_ => require(is.readInt() == 0)}
     // file length in bits
-    length = 16 * is.readInt() - 50 * 16
+    length = 16 * is.readInt().toLong - 50 * 16
     remaining = length
     val version = EndianUtils.swapInteger(is.readInt())
     require(version == 1000)


### PR DESCRIPTION
file size was stored in a Int. so we can not handle files with more than 2GB

changed to a Long value