### PR TITLE
Fix display in Databricks notebooks

### DIFF
--- a/src/main/scala/magellan/Line.scala
+++ b/src/main/scala/magellan/Line.scala
@@ -15,8 +15,9 @@
  */
 package magellan
 
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty}
 import org.apache.spark.sql.types._
-import magellan.Shape.{ccw, area}
+import magellan.Shape.{area, ccw}
 
 /**
  * Line segment between two points.
@@ -30,7 +31,10 @@ class Line extends Shape {
   def setStart(start: Point) { this.start = start }
   def setEnd(end: Point) { this.end = end }
 
+  @JsonProperty
   def getStart() = start
+
+  @JsonProperty
   def getEnd() = end
 
   @inline private [magellan] def contains(point: Point): Boolean = {
@@ -107,7 +111,7 @@ class Line extends Shape {
     }
   }
 
-  @inline private [magellan] def getMid(): Point = {
+  @JsonIgnore @inline private [magellan] def getMid(): Point = {
     Point(start.getX() + (end.getX() - start.getX())/ 2, start.getY() + (end.getY() - start.getY())/ 2)
   }
 

--- a/src/main/scala/magellan/Point.scala
+++ b/src/main/scala/magellan/Point.scala
@@ -16,6 +16,7 @@
 
 package magellan
 
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty}
 import org.apache.spark.sql.types._
 import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL._
@@ -63,8 +64,10 @@ class Point extends Shape {
     this.y = y
   }
 
+  @JsonProperty
   def getX(): Double = x
 
+  @JsonProperty
   def getY(): Double = y
 
   /**
@@ -75,6 +78,7 @@ class Point extends Shape {
    */
   override def transform(fn: (Point) => Point): Point = fn(this)
 
+  @JsonProperty
   override def getType(): Int = 1
 
   override def jsonValue: JValue =
@@ -84,7 +88,11 @@ class Point extends Shape {
       ("x" -> x) ~
       ("y" -> y)
 
+  @JsonProperty
   override def boundingBox: ((Double, Double), (Double, Double)) = ((x, y), (x, y))
+
+  @JsonIgnore
+  override def isEmpty(): Boolean = true
 
 }
 

--- a/src/main/scala/magellan/PolyLine.scala
+++ b/src/main/scala/magellan/PolyLine.scala
@@ -16,6 +16,7 @@
 
 package magellan
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import org.apache.spark.sql.types._
 
 import scala.util.control.Breaks._
@@ -34,6 +35,12 @@ class PolyLine(
     override val boundingBox: Tuple2[Tuple2[Double, Double], Tuple2[Double, Double]]) extends Shape {
 
   override def getType(): Int = 3
+
+  @JsonProperty
+  private [magellan] def getXCoordinates(): Array[Double] = xcoordinates
+
+  @JsonProperty
+  private [magellan] def getYCoordinates(): Array[Double] = ycoordinates
 
   private [magellan] def contains(point:Point): Boolean = {
     var startIndex = 0
@@ -132,7 +139,7 @@ class PolyLine(
       ("points" -> JArray(points.map(_.jsonValue).toList))*/
 }
 
-private[magellan] object PolyLine {
+object PolyLine {
 
   def apply(indices: Array[Int], points: Array[Point]): PolyLine = {
     // look for the extremities

--- a/src/main/scala/magellan/Polygon.scala
+++ b/src/main/scala/magellan/Polygon.scala
@@ -16,6 +16,7 @@
 
 package magellan
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import org.apache.spark.sql.types._
 
 /**
@@ -44,6 +45,12 @@ class Polygon(
     val above = (point.getY() < slope * (point.getX() - start.getX()) + start.getY())
     ((cond1 || cond2) && above )
   }
+
+  @JsonProperty
+  def getXCoordinates(): Array[Double] = xcoordinates
+
+  @JsonProperty
+  def getYCoordinates(): Array[Double] = ycoordinates
 
   private [magellan] def contains(point: Point): Boolean = {
     var startIndex = 0
@@ -244,6 +251,7 @@ class Polygon(
     }
   }
 
+  @JsonProperty
   override def getType(): Int = 5
 
   /**

--- a/src/main/scala/magellan/Shape.scala
+++ b/src/main/scala/magellan/Shape.scala
@@ -16,6 +16,7 @@
 
 package magellan
 
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types._
 
@@ -30,6 +31,7 @@ trait Shape extends DataType with Serializable {
 
   override def asNullable: DataType = this
 
+  @JsonProperty
   def getType(): Int
 
   /**
@@ -173,6 +175,7 @@ trait Shape extends DataType with Serializable {
 
   }
 
+  @JsonProperty
   def boundingBox: Tuple2[Tuple2[Double, Double], Tuple2[Double, Double]]
 
   /**
@@ -235,6 +238,7 @@ trait Shape extends DataType with Serializable {
    *
    * @return <code>true</code> if this <code>Shape</code> does not cover any points
    */
+  @JsonIgnore
   def isEmpty(): Boolean = ???
 
   /**

--- a/src/test/scala/magellan/LineSuite.scala
+++ b/src/test/scala/magellan/LineSuite.scala
@@ -15,6 +15,7 @@
  */
 package magellan
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
 
@@ -78,6 +79,12 @@ class LineSuite extends FunSuite with TestSparkContext {
     assert(!x.contains(z))
     assert(x.contains(w))
     assert(!x.contains(u))
+  }
 
+  test("jackson serialization") {
+    val s = new ObjectMapper().writeValueAsString(Line(Point(0.0, 0.0), Point(1.0, 1.0)))
+    assert(s.contains("boundingBox"))
+    assert(s.contains("start"))
+    assert(s.contains("end"))
   }
 }

--- a/src/test/scala/magellan/PointSuite.scala
+++ b/src/test/scala/magellan/PointSuite.scala
@@ -42,4 +42,20 @@ class PointSuite extends FunSuite with TestSparkContext {
     val serializedPoint = pointUDT.deserialize(row)
     assert(point.equals(serializedPoint))
   }
+
+  test("point udf") {
+    val sqlContext = this.sqlContext
+    import sqlContext.implicits._
+    val points = sc.parallelize(Seq((-1.0, -1.0), (-1.0, 1.0), (1.0, -1.0))).toDF("x", "y")
+    import org.apache.spark.sql.functions.udf
+    val toPointUDF = udf{(x:Double,y:Double) => Point(x,y) }
+    val point = points.withColumn("point", toPointUDF('x, 'y))
+      .select('point)
+      .first()(0)
+      .asInstanceOf[Point]
+
+    assert(point.getX() === -1.0)
+    assert(point.getY() === -1.0)
+  }
+
 }

--- a/src/test/scala/magellan/PointSuite.scala
+++ b/src/test/scala/magellan/PointSuite.scala
@@ -15,6 +15,7 @@
  */
 package magellan
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
 
@@ -56,6 +57,13 @@ class PointSuite extends FunSuite with TestSparkContext {
 
     assert(point.getX() === -1.0)
     assert(point.getY() === -1.0)
+  }
+
+  test("jackson serialization") {
+    val s = new ObjectMapper().writeValueAsString(Point(1.0, 1.0))
+    assert(s.contains("boundingBox"))
+    assert(s.contains("x"))
+    assert(s.contains("y"))
   }
 
 }

--- a/src/test/scala/magellan/PolygonSuite.scala
+++ b/src/test/scala/magellan/PolygonSuite.scala
@@ -16,6 +16,7 @@
 package magellan
 
 import com.esri.core.geometry.{GeometryEngine, Point => ESRIPoint, Polygon => ESRIPolygon, Polyline => ESRIPolyLine}
+import com.fasterxml.jackson.databind.ObjectMapper
 import magellan.TestingUtils._
 import org.apache.spark.sql.types._
 import org.scalatest.FunSuite
@@ -250,6 +251,20 @@ class PolygonSuite extends FunSuite {
 
     esriPoint.setXY(0.75, 0.75)
     assert(GeometryEngine.contains(esriPolygon, esriPoint, null))
+  }
+
+  test("jackson serialization") {
+    val ring = Array(Point(1.0, 1.0), Point(1.0, -1.0),
+      Point(-1.0, -1.0), Point(-1.0, 1.0), Point(1.0, 1.0),
+      Point(0.5, 0), Point(0, 0.5), Point(-0.5, 0),
+      Point(0, -0.5), Point(0.5, 0)
+    )
+
+    val polygon = Polygon(Array(0, 5), ring)
+    val s = new ObjectMapper().writeValueAsString(polygon)
+    assert(s.contains("boundingBox"))
+    assert(s.contains("xcoordinates"))
+    assert(s.contains("ycoordinates"))
   }
 
   def fromESRI(esriPolygon: ESRIPolygon): Polygon = {


### PR DESCRIPTION
Databricks display system treats isEmpty as a property so display on a dataframe can fail sometimes