### PR TITLE
Faster WKT Parser

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,9 @@ sparkComponents := Seq("core", "sql")
 libraryDependencies ++= Seq(
   "commons-io" % "commons-io" % "2.4",
   "org.slf4j" % "slf4j-api" % "1.7.5" % "provided",
+  "com.lihaoyi" % "fastparse_2.11" % "0.4.2",
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",
+  "com.vividsolutions" % "jts" % "1.13" % "test",
   "com.esri.geometry" % "esri-geometry-api" % "1.2.1" % "test"
 )
 

--- a/src/main/scala/org/apache/spark/sql/types/WKT.scala
+++ b/src/main/scala/org/apache/spark/sql/types/WKT.scala
@@ -38,7 +38,7 @@ case class WKT(override val child: Expression)
       s"" +
         s"String text = ${c1}.toString();\n" +
         s"magellan.Shape shape = (magellan.Shape) " +
-        s"magellan.WKTParser.parseAll(magellan.WKTParser.expr(), text).get();\n" +
+        s"magellan.WKTParser.parseAll(text);\n" +
         s"Integer t = shape.getType();\n" +
         s"org.apache.spark.sql.types.UserDefinedType<magellan.Shape> serializer =" +
         s" (org.apache.spark.sql.types.UserDefinedType<magellan.Shape>) serializers.get(t);\n" +

--- a/src/test/scala/magellan/WKTParserSuite.scala
+++ b/src/test/scala/magellan/WKTParserSuite.scala
@@ -16,61 +16,58 @@
 
 package magellan
 
+import com.vividsolutions.jts.io.WKTReader
 import org.scalatest.FunSuite
 
 class WKTParserSuite extends FunSuite {
 
+  test("parse int") {
+    val parsed = WKTParser.int.parse("-30")
+    assert(parsed.index === 3)
+    assert(parsed.get.value ===  "-30")
+  }
+
+  test("parse float") {
+    val parsed = WKTParser.float.parse("-79.470579")
+    assert(parsed.get.value === "-79.470579")
+  }
+
+  test("parse number") {
+    val parsed = WKTParser.number.parse("-79.470579")
+    assert(parsed.get.value === -79.470579)
+  }
+
   test("parse point") {
-    val point =
-      WKTParser.parse(
-        WKTParser.point,
-        "POINT (30 10)")
-    assert(point.successful)
-    val p: Point = point.get
+    val parsed = WKTParser.point.parse("POINT (30 10)")
+    assert(parsed.index == 13)
+    val p = parsed.get.value
     assert(p.getX() === 30.0)
     assert(p.getY() === 10.0)
   }
 
   test("parse linestring") {
-    var linestring =
-      WKTParser.parse(
-        WKTParser.linestring,
-        "LINESTRING (30 10, 10 30, 40 40)")
-
-    assert(linestring.successful)
-    val p: PolyLine = linestring.get
+    var parsed = WKTParser.linestring.parse("LINESTRING (30 10, 10 30, 40 40)")
+    var p: PolyLine = parsed.get.value
     assert(p.indices.length === 1)
     assert(p.xcoordinates.length === 3)
 
-    linestring =
-      WKTParser.parse(
-        WKTParser.linestring,
-        "LINESTRING (-79.470579 35.442827,-79.469465 35.444889,-79.468907 35.445829,-79.468294 35.446608,-79.46687 35.447893)")
+    parsed = WKTParser.linestring.parse(
+      "LINESTRING (-79.470579 35.442827,-79.469465 35.444889,-79.468907 35.445829,-79.468294 35.446608,-79.46687 35.447893)")
 
-    assert(linestring.successful)
+    p = parsed.get.value
+    assert(p.xcoordinates.length === 5)
 
   }
 
   test("parse polygon without holes") {
-    val polygon =
-      WKTParser.parse(
-        WKTParser.polygonWithoutHoles,
-        "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))")
-
-    assert(polygon.successful)
-    val p: Polygon = polygon.get
+    var parsed = WKTParser.polygonWithoutHoles.parse("POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))")
+    val p: Polygon = parsed.get.value
     assert(p.xcoordinates.length === 5)
   }
 
   test("parse polygon with holes") {
-    val polygon =
-      WKTParser.parse(
-        WKTParser.polygonWithHoles,
-        "POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10), (20 30, 35 35, 30 20, 20 30))"
-      )
-
-    assert(polygon.successful)
-    val p: Polygon = polygon.get
+    val parsed = WKTParser.polygonWithHoles.parse("POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10), (20 30, 35 35, 30 20, 20 30))")
+    val p: Polygon = parsed.get.value
     assert(p.indices.length == 2)
     assert(p.indices(1) == 5)
     assert(p.xcoordinates(4) === 35.0)
@@ -78,10 +75,47 @@ class WKTParserSuite extends FunSuite {
   }
 
   test("parse") {
-    val shape = WKTParser.parseAll(WKTParser.expr, "LINESTRING (30 10, 10 30, 40 40)")
-    assert(shape.successful)
-    val s = shape.get
-    assert(s.isInstanceOf[PolyLine])
+    val shape = WKTParser.parseAll("LINESTRING (30 10, 10 30, 40 40)")
+    assert(shape.isInstanceOf[PolyLine])
   }
 
+  test("perf") {
+
+    def time[R](block: => R): R = {
+      val t0 = System.nanoTime()
+      val result = block    // call-by-name
+      val t1 = System.nanoTime()
+      println("Elapsed time: " + (t1 - t0)/1E6 + "ms")
+      result
+    }
+
+    def exec(text: String, n: Int, fn: (String) => Any) = {
+      var i = 0
+      while (i < n) {
+        fn(text)
+        i += 1
+      }
+    }
+
+    val text = "LINESTRING (30 10, 10 30, 40 40)"
+    val n = 100000
+
+    time(exec(text, n, parseUsingJTS))
+    time(exec(text, n, (s: String) => WKTParser.linestring.parse(s)))
+
+  }
+
+  private def parseUsingJTS(text: String): Shape = {
+    val wkt = new WKTReader()
+    val polyline = wkt.read(text)
+    val coords = polyline.getCoordinates()
+    val points = new Array[Point](coords.length)
+    var i = 0
+    while (i < coords.length) {
+      val coord = coords(i)
+      points.update(i, Point(coord.x, coord.y))
+      i += 1
+    }
+    PolyLine(Array(0), points)
+  }
 }


### PR DESCRIPTION
Scala's parser combinators while elegant are not fast enough for parsing, especially when used in tight loops. Replacing with fast parse which is closer to hand implemented parsing while retaining the readability and extensibility of a parser combinator.