### PR TITLE
simplify indexing schema

### DIFF
--- a/src/main/scala/magellan/index/Indexer.scala
+++ b/src/main/scala/magellan/index/Indexer.scala
@@ -51,19 +51,13 @@ trait Indexer[T <: Index] extends Serializable {
     */
   def indexWithMeta(shape: Shape, precision: Int): Seq[(T, Relate)]
 
-  def indexWithMetaAsJava(shape: Shape, precision: Int): (util.List[T], util.List[String]) = {
-    val curves = new util.ArrayList[T]()
-    val relations = new util.ArrayList[String]()
+  def indexWithMetaAsJava(shape: Shape, precision: Int): util.List[(T, String)] = {
+    val indices = new util.ArrayList[(T, String)]()
     indexWithMeta(shape, precision) foreach {
       case (index: T, relation: Relate) =>
-        curves.add(index)
-        relations.add(relation.name())
+        indices.add((index, relation.name()))
     }
-    (curves, relations)
-  }
-
-  def indexAsJava(shape: Shape, precision: Int): java.util.Collection[T] = {
-    indexWithMetaAsJava(shape, precision)._1
+    indices
   }
 
 }

--- a/src/test/scala/magellan/ShapefileSuite.scala
+++ b/src/test/scala/magellan/ShapefileSuite.scala
@@ -106,25 +106,7 @@ class ShapefileSuite extends FunSuite with TestSparkContext {
       load(path)
     import sqlCtx.implicits._
     import org.apache.spark.sql.functions.explode
-    assert(df.select(explode($"index.curve").as("curve")).count() === 2)
-  }
-
-  test("shapefile-relation: spatial join plan") {
-    val sqlCtx = this.sqlContext
-    val path = this.getClass.getClassLoader.getResource("testshapefile/").getPath
-    import sqlCtx.implicits._
-
-    val polygons = sqlCtx.read.
-      format("magellan").
-      load(path).
-      select($"polygon")
-
-
-    val df = sc.parallelize(Seq((35.7, -122.3))).toDF("lat", "lon")
-    val points = df.withColumn("point", point($"lon", $"lat"))
-
-    println(points.join(polygons).where($"point" within $"polygon").count())
+    assert(df.select(explode($"index")).count() === 2)
+    assert(df.select(explode($"index").as("index")).groupBy($"index.relation").count().count() === 1)
   }
 }
-
-


### PR DESCRIPTION
minor refactoring to simplify the schema for indexing.
output an array of struct fields (curve, relation) instead of separate arrays of curves and relations.