### PR TITLE
Transparent Spatial Join for Within

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ cache:
 # https://github.com/travis-ci/travis-ci/issues/1519.
 matrix:
   include: 
-    - jdk: openjdk-8-jdk
+    - jdk: oraclejdk8 
       scala: 2.11.8
       env: TEST_HADOOP_VERSION="2.7.3" TEST_SPARK_VERSION="2.2.0"
-    - jdk: openjdk-8-jdk
+    - jdk: oraclejdk8
       scala: 2.11.8
       env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.1.0"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ cache:
 # https://github.com/travis-ci/travis-ci/issues/1519.
 matrix:
   include: 
-    - jdk: openjdk7
+    - jdk: openjdk8
+      scala: 2.11.8
+      env: TEST_HADOOP_VERSION="2.7.3" TEST_SPARK_VERSION="2.2.0"
+    - jdk: openjdk8
       scala: 2.11.8
       env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.1.0"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ cache:
 # https://github.com/travis-ci/travis-ci/issues/1519.
 matrix:
   include: 
-    - jdk: openjdk8
+    - jdk: openjdk-8-jdk
       scala: 2.11.8
       env: TEST_HADOOP_VERSION="2.7.3" TEST_SPARK_VERSION="2.2.0"
-    - jdk: openjdk8
+    - jdk: openjdk-8-jdk
       scala: 2.11.8
       env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.1.0"
 script:

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalaVersion := "2.11.8"
 
 crossScalaVersions := Seq("2.11.8")
 
-sparkVersion := "2.1.0"
+sparkVersion := "2.2.0"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 
@@ -16,13 +16,13 @@ testSparkVersion := sys.props.get("spark.testVersion").getOrElse(sparkVersion.va
 
 val testHadoopVersion = settingKey[String]("The version of Hadoop to test against.")
 
-testHadoopVersion := sys.props.getOrElse("hadoop.testVersion", "2.2.0")
+testHadoopVersion := sys.props.getOrElse("hadoop.testVersion", "2.7.3")
 
 sparkComponents := Seq("core", "sql")
 
 libraryDependencies ++= Seq(
   "commons-io" % "commons-io" % "2.4",
-  "org.slf4j" % "slf4j-api" % "1.7.5" % "provided",
+  "org.slf4j" % "slf4j-api" % "1.7.16" % "provided",
   "com.lihaoyi" % "fastparse_2.11" % "0.4.3" % "provided",
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",
   "com.vividsolutions" % "jts" % "1.13" % "test",

--- a/src/main/scala/magellan/DoubleArrayData.scala
+++ b/src/main/scala/magellan/DoubleArrayData.scala
@@ -31,6 +31,10 @@ class DoubleArrayData(v: Array[Double]) extends ArrayData {
     new DoubleArrayData(a)
   }
 
+  def setNullAt(i: Int): Unit = ???
+
+  def update(i: Int,value: Any): Unit = ???
+
   override val array: Array[Any] = v.map(_.asInstanceOf[Any])
 
   override def getUTF8String(ordinal: Int): UTF8String = ???

--- a/src/main/scala/magellan/IntegerArrayData.scala
+++ b/src/main/scala/magellan/IntegerArrayData.scala
@@ -31,6 +31,10 @@ class IntegerArrayData(v: Array[Int]) extends ArrayData {
     new IntegerArrayData(a)
   }
 
+  def setNullAt(i: Int): Unit = ???
+
+  def update(i: Int,value: Any): Unit = ???
+
   override val array: Array[Any] = v.map(_.asInstanceOf[Any])
 
   override def getUTF8String(ordinal: Int): UTF8String = ???

--- a/src/main/scala/magellan/OsmFileRelation.scala
+++ b/src/main/scala/magellan/OsmFileRelation.scala
@@ -1,12 +1,12 @@
 package magellan
 
-import com.google.common.base.Objects
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.SQLContext
-import org.apache.spark.Partitioner
+import java.util.Objects
 
 import magellan.io._
 import magellan.mapreduce._
+import org.apache.spark.Partitioner
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SQLContext
 
 private[magellan] case class WayKey(val id: String, val index: Int)
 
@@ -140,5 +140,5 @@ case class OsmFileRelation(
       .union(nodes.map({ node => (node.point, Some(node.tags))}))
   }
 
-  override def hashCode(): Int = Objects.hashCode(path, schema)
+  override def hashCode(): Int = Objects.hash(path, schema)
 }

--- a/src/main/scala/magellan/ShapefileRelation.scala
+++ b/src/main/scala/magellan/ShapefileRelation.scala
@@ -16,15 +16,15 @@
 
 package magellan
 
-import scala.collection.JavaConversions._
+import java.util.Objects
 
-import com.google.common.base.Objects
+import magellan.io._
+import magellan.mapreduce._
 import org.apache.hadoop.io.{MapWritable, Text}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SQLContext
 
-import magellan.io._
-import magellan.mapreduce._
+import scala.collection.JavaConversions._
 
 /**
  * A Shapefile relation is the entry point for working with Shapefile formats.
@@ -66,5 +66,5 @@ case class ShapeFileRelation(
     dataRdd.leftOuterJoin(metadataRdd).map(f => f._2)
   }
 
-  override def hashCode(): Int = Objects.hashCode(path, schema)
+  override def hashCode(): Int = Objects.hash(path, schema)
 }

--- a/src/main/scala/magellan/SpatialRelation.scala
+++ b/src/main/scala/magellan/SpatialRelation.scala
@@ -30,13 +30,13 @@ private[magellan] trait SpatialRelation extends BaseRelation with PrunedFiltered
 
   @transient val sc = sqlContext.sparkContext
 
-  Utils.injectRules(sqlContext.sparkSession)
-
   val parameters: Map[String, String]
 
   private val indexer = new ZOrderCurveIndexer()
 
   private val precision = parameters.getOrElse("magellan.index.precision", "30").toInt
+
+  Utils.injectRules(sqlContext.sparkSession, parameters)
 
   private val indexSchema = ArrayType(new StructType()
     .add("curve", new ZOrderCurveUDT, false)

--- a/src/main/scala/magellan/Utils.scala
+++ b/src/main/scala/magellan/Utils.scala
@@ -21,9 +21,9 @@ import org.apache.spark.sql.SparkSession
 
 object Utils {
 
-  def injectRules(session: SparkSession): Unit = {
+  def injectRules(session: SparkSession, params: Map[String, String]): Unit = {
     if (!session.experimental.extraOptimizations.exists(_.isInstanceOf[SpatialJoin])) {
-      session.experimental.extraOptimizations ++= (Seq(SpatialJoin(session)))
+      session.experimental.extraOptimizations ++= (Seq(SpatialJoin(session, params)))
     }
   }
 }

--- a/src/main/scala/magellan/catalyst/SpatialJoin.scala
+++ b/src/main/scala/magellan/catalyst/SpatialJoin.scala
@@ -16,20 +16,65 @@
 
 package magellan.catalyst
 
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, EqualTo, Explode, Expression, Inline, Literal, NamedExpression, Or}
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.logical.{Generate, _}
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{Column, SparkSession}
 
-private[magellan] case class SpatialJoin(session: SparkSession) extends Rule[LogicalPlan] {
+private[magellan] case class SpatialJoin(
+    session: SparkSession,
+    params: Map[String, String])
+  extends Rule[LogicalPlan] {
+
+  private val indexerType = Indexer.dataType
+  private val curveType = new ZOrderCurveUDT().sqlType
+  private val precision = params.getOrElse("magellan.index.precision", "30").toInt
 
   override def apply(plan: LogicalPlan): LogicalPlan = {
-      plan transformUp(PartialFunction(p => p match {
-        case p @ Join(l, r, joinType, condition) => {
-          p
-        }
-        case _ => p
-      }
-    ))
+
+    plan transformUp {
+      case p @ Join(
+            Generate(Inline(_: Indexer), _, _, _, _, _),
+            Generate(Inline(_: Indexer), _, _, _, _, _), _, _) => p
+      case p @ Join(l, r, Inner, Some(cond @ Within(a, b))) =>
+
+        // The following optimizations are done to this plan:
+        // 1. Check if there are indices on either side.
+        //    If an index exists, use it otherwise create a new index and explode it
+        // 2. Inner Join on the curve and add an additional filter on the relation
+
+
+        // determine which is the left project and which is the right projection in Within
+        val (leftProjection, rightProjection) =
+          l.outputSet.find(a.references.contains(_)) match {
+            case Some(_) => (a, b)
+            case None => (b, a)
+          }
+
+        val c1 = attr("curve", curveType)
+        val r1 = attr("relation", StringType)
+        val c2 = attr("curve", curveType)
+        val r2 = attr("relation", StringType)
+        val shortcutRelation = EqualTo(r1, Literal("Within"))
+        val transformedCondition =  Or(shortcutRelation, cond)
+
+        val leftIndexer = l.outputSet.find(_.dataType == indexerType)
+          .fold[Expression](Indexer(leftProjection, precision))(identity)
+
+        val rightIndexer = r.outputSet.find(_.dataType == indexerType)
+          .fold[Expression](Indexer(rightProjection, precision))(identity)
+
+        Join(
+          Generate(Inline(leftIndexer), true, false, None, Seq(c1, r1), l),
+          Generate(Inline(rightIndexer), true, false, None, Seq(c2, r2), r),
+          Inner,
+          Some(And(EqualTo(c1, c2), transformedCondition)))
+    }
   }
 
+  private def attr(name: String, dt: DataType): AttributeReference = {
+    AttributeReference(name, dt)()
+  }
 }

--- a/src/main/scala/magellan/index/ZOrderCurve.scala
+++ b/src/main/scala/magellan/index/ZOrderCurve.scala
@@ -80,4 +80,19 @@ class ZOrderCurve(
   }
 
   override def toString = s"ZOrderCurve($xmin, $ymin, $xmax, $ymax, $precision, $bits, $code)"
+
+  def canEqual(other: Any): Boolean = other.isInstanceOf[ZOrderCurve]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ZOrderCurve =>
+      (that canEqual this) &&
+        precision == that.precision &&
+        bits == that.bits
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    val state = Seq(precision, bits)
+    state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
+  }
 }

--- a/src/main/scala/org/apache/spark/sql/types/Indexer.scala
+++ b/src/main/scala/org/apache/spark/sql/types/Indexer.scala
@@ -19,10 +19,11 @@ package org.apache.spark.sql.types
 import magellan.catalyst.MagellanExpression
 import magellan.index.{ZOrderCurve, ZOrderCurveIndexer}
 import magellan.{Relate, Shape}
-import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
-import org.apache.spark.sql.catalyst.expressions.{Expression, UnaryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Expression, GenericInternalRow, UnaryExpression}
+import org.apache.spark.sql.catalyst.util.GenericArrayData
+import org.apache.spark.unsafe.types.UTF8String
 
 import scala.collection.mutable.ListBuffer
 
@@ -32,27 +33,38 @@ case class Indexer(
   extends UnaryExpression with MagellanExpression {
 
   private val indexer = new ZOrderCurveIndexer()
+  private val indexUDT = Indexer.indexUDT
 
   assert(precision % 5 == 0)
 
   protected override def nullSafeEval(input: Any): Any = {
     val shape = newInstance(input.asInstanceOf[InternalRow])
-    val indices = indexer.indexWithMeta(shape, precision) map {
+    val rows = ListBuffer[InternalRow]()
+    indexer.indexWithMeta(shape, precision) foreach  {
       case (index: ZOrderCurve, relation: Relate) => {
-        (index, relation.name())
+        val row = new GenericInternalRow(2)
+        row.update(0, indexUDT.serialize(index))
+        row.update(1, UTF8String.fromString(relation.name()))
+        rows.+= (row)
       }
     }
 
-    indices
+    new GenericArrayData(rows)
   }
 
   override def nullable: Boolean = false
 
-  override def dataType: DataType = ArrayType(new StructType()
-    .add("curve", new ZOrderCurveUDT, false)
-    .add("relation", StringType, false))
+  override def dataType: DataType = Indexer.dataType
 
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val childTypeVar = ctx.freshName("childType")
+    val childShapeVar = ctx.freshName("childShape")
+    val shapeSerializerVar = ctx.freshName("shapeSerializer")
+    val indexerVar = ctx.freshName("indexer")
+    val precisionVar = ctx.freshName("precision")
+    val resultsVar = ctx.freshName("results")
+    val indexSerializerVar = ctx.freshName("indexSerializer")
+
     ctx.addMutableState(classOf[java.util.HashMap[Integer, UserDefinedType[Shape]]].getName, "serializers",
       "serializers = new java.util.HashMap<Integer, org.apache.spark.sql.types.UserDefinedType<magellan.Shape>>() ; \n" +
         "serializers.put(1, new org.apache.spark.sql.types.PointUDT()); \n" +
@@ -62,33 +74,42 @@ case class Indexer(
         "")
 
     val idx = ctx.references.length
-    ctx.addReferenceObj("indexer", indexer)
-    ctx.addReferenceObj("precision", precision)
-    ctx.addReferenceObj("zordercurveudt", new ZOrderCurveUDT)
+    ctx.addReferenceObj(s"$indexerVar", indexer)
+    ctx.addReferenceObj(s"$precisionVar", precision)
+    ctx.addReferenceObj(s"$indexSerializerVar", new ZOrderCurveUDT)
 
     nullSafeCodeGen(ctx, ev, (c1) => {
       s"" +
-        s"magellan.index.ZOrderCurveIndexer indexer = (magellan.index.ZOrderCurveIndexer)references[$idx]; \n" +
-        s"Integer childType = $c1.getInt(0); \n" +
-        s"Integer precision = (Integer) references[$idx + 1]; \n" +
-        s"org.apache.spark.sql.types.ZOrderCurveUDT udt = " +
+        s"magellan.index.ZOrderCurveIndexer $indexerVar = (magellan.index.ZOrderCurveIndexer)references[$idx]; \n" +
+        s"Integer $childTypeVar = $c1.getInt(0); \n" +
+        s"Integer $precisionVar = (Integer) references[$idx + 1]; \n" +
+        s"org.apache.spark.sql.types.ZOrderCurveUDT $indexSerializerVar = " +
         s"  (org.apache.spark.sql.types.ZOrderCurveUDT) references[$idx + 2]; \n" +
-        "org.apache.spark.sql.types.UserDefinedType<magellan.Shape> serializer = " +
+        s"org.apache.spark.sql.types.UserDefinedType<magellan.Shape> $shapeSerializerVar = " +
         s"((org.apache.spark.sql.types.UserDefinedType<magellan.Shape>)" +
-        s"serializers.get(childType)); \n" +
-        s"magellan.Shape childShape = (magellan.Shape)" +
-        s"serializer.deserialize($c1); \n" +
+        s"serializers.get($childTypeVar)); \n" +
+        s"magellan.Shape $childShapeVar = (magellan.Shape)" +
+        s"$shapeSerializerVar.deserialize($c1); \n" +
         s"java.util.List<scala.Tuple2<magellan.index.ZOrderCurve, String>> v =" +
-        s" indexer.indexWithMetaAsJava(childShape, precision); \n" +
-        s"java.util.List<InternalRow> c = new java.util.ArrayList<InternalRow>(v.size()); \n" +
+        s" indexer.indexWithMetaAsJava($childShapeVar, $precisionVar); \n" +
+        s"java.util.List<InternalRow> $resultsVar = new java.util.ArrayList<InternalRow>(v.size()); \n" +
         s"for(scala.Tuple2<magellan.index.ZOrderCurve, String> i : v) { \n" +
         s"  org.apache.spark.sql.catalyst.expressions.GenericInternalRow row =\n" +
         s"  new org.apache.spark.sql.catalyst.expressions.GenericInternalRow(2);\n" +
-        s"  row.update(0, udt.serialize(i._1()));\n" +
+        s"  row.update(0, $indexSerializerVar.serialize(i._1()));\n" +
         s"  row.update(1, org.apache.spark.unsafe.types.UTF8String.fromString((String)i._2())); \n" +
-        s"  c.add(row); \n" +
+        s"  $resultsVar.add(row); \n" +
         s"}\n" +
-        s"${ev.value} = new org.apache.spark.sql.catalyst.util.GenericArrayData(c); \n"
+        s"${ev.value} = new org.apache.spark.sql.catalyst.util.GenericArrayData($resultsVar); \n"
     })
   }
+}
+
+object Indexer {
+
+  val indexUDT = new ZOrderCurveUDT()
+
+  val dataType = ArrayType(new StructType()
+    .add("curve", indexUDT, false)
+    .add("relation", StringType, false))
 }

--- a/src/test/scala/magellan/TestSparkContext.scala
+++ b/src/test/scala/magellan/TestSparkContext.scala
@@ -16,30 +16,37 @@
 
 package magellan
 
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.{SQLContext, SparkSession}
 import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.{BeforeAndAfterAll, Suite}
 
 trait TestSparkContext extends BeforeAndAfterAll { self: Suite =>
   @transient var sc: SparkContext = _
+  @transient var spark: SparkSession = _
   @transient var sqlContext: SQLContext = _
 
   override def beforeAll() {
     super.beforeAll()
     val conf = new SparkConf()
       .setMaster("local[2]")
-      .setAppName("MLlibUnitTest")
+      .setAppName("MagellanUnitTest")
       .set("spark.sql.crossJoin.enabled", "true")
-    sc = new SparkContext(conf)
-    sqlContext = new SQLContext(sc)
-    sqlContext.setConf("spark.sql.crossJoin.enabled", "true")
+
+    spark = SparkSession.builder()
+      .config(conf)
+      .config("spark.sql.crossJoin.enabled", "true")
+      .getOrCreate()
+    sqlContext = spark.sqlContext
+    sc = spark.sparkContext
   }
 
   override def afterAll() {
-    sqlContext = null
-    if (sc != null) {
-      sc.stop()
+
+    if (spark != null) {
+      spark.stop()
     }
+    spark = null
+    sqlContext = null
     sc = null
     super.afterAll()
   }

--- a/src/test/scala/magellan/catalyst/ExpressionSuite.scala
+++ b/src/test/scala/magellan/catalyst/ExpressionSuite.scala
@@ -17,7 +17,6 @@
 package magellan.catalyst
 
 import magellan._
-import org.apache.spark.sql.Row
 import org.apache.spark.sql.magellan.dsl.expressions._
 import org.scalatest.FunSuite
 

--- a/src/test/scala/magellan/catalyst/SpatialJoinSuite.scala
+++ b/src/test/scala/magellan/catalyst/SpatialJoinSuite.scala
@@ -1,0 +1,131 @@
+/**
+  * Copyright 2015 Ram Sriharsha
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package magellan.catalyst
+
+import magellan.{Point, Polygon, TestSparkContext, Utils}
+import org.apache.spark.sql.catalyst.optimizer.PushPredicateThroughJoin
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+import org.apache.spark.sql.functions.broadcast
+import org.apache.spark.sql.magellan.dsl.expressions._
+import org.scalatest.FunSuite
+
+class SpatialJoinSuite extends FunSuite with TestSparkContext {
+
+  object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("pushdown filter through join", Once, PushPredicateThroughJoin) ::
+      Batch("spatial join", FixedPoint(100), new SpatialJoin(spark, Map())) :: Nil
+  }
+
+  override def beforeAll() {
+    super.beforeAll()
+    Utils.injectRules(spark, Map())
+  }
+
+  test("spatial join in plan") {
+
+    val sqlCtx = this.sqlContext
+    import sqlCtx.implicits._
+    val ring = Array(Point(1.0, 1.0), Point(1.0, -1.0),
+      Point(-1.0, -1.0), Point(-1.0, 1.0),
+      Point(1.0, 1.0))
+    val polygons = sc.parallelize(Seq(
+      ("1", Polygon(Array(0), ring))
+    )).toDF("id", "polygon")
+
+    val points = sc.parallelize(Seq(
+      ("a", 1, Point(0.0, 0.0)),
+      ("b" , 2, Point(2.0, 2.0))
+    )).toDF("name", "value", "point")
+
+    val joined = points.join(polygons).where($"point" within $"polygon")
+
+    val optimizedPlan = Optimize.execute(joined.queryExecution.analyzed)
+    assert(optimizedPlan.toString().contains("Generate inline(indexer"))
+    assert(joined.count() === 1)
+
+  }
+
+  test("use existing indices in spatial join") {
+    val sqlCtx = this.sqlContext
+    import sqlCtx.implicits._
+    val ring = Array(Point(1.0, 1.0), Point(1.0, -1.0),
+      Point(-1.0, -1.0), Point(-1.0, 1.0),
+      Point(1.0, 1.0))
+    val polygons = sc.parallelize(Seq(
+      ("1", Polygon(Array(0), ring))
+    )).toDF("id", "polygon").withColumn("index", $"polygon" index 30)
+
+    val points = sc.parallelize(Seq(
+      ("a", 1, Point(0.0, 0.0)),
+      ("b" , 2, Point(2.0, 2.0))
+    )).toDF("name", "value", "point")
+
+    val joined = polygons.join(points).where($"point" within $"polygon")
+
+    val optimizedPlan = Optimize.execute(joined.queryExecution.analyzed)
+
+    assert(optimizedPlan.toString().contains("Generate inline(index#"))
+    assert(optimizedPlan.toString().contains("Generate inline(indexer"))
+    assert(joined.count() === 1)
+  }
+
+  test("order of expressions in filter does not matter") {
+
+    val sqlCtx = this.sqlContext
+    import sqlCtx.implicits._
+    val ring = Array(Point(1.0, 1.0), Point(1.0, -1.0),
+      Point(-1.0, -1.0), Point(-1.0, 1.0),
+      Point(1.0, 1.0))
+    val polygons = sc.parallelize(Seq(
+      ("1", Polygon(Array(0), ring))
+    )).toDF("id", "polygon")
+
+    val points = sc.parallelize(Seq(
+      ("a", 1, Point(0.0, 0.0)),
+      ("b" , 2, Point(2.0, 2.0))
+    )).toDF("name", "value", "point")
+
+    val joined = polygons.join(points).where($"point" within $"polygon")
+
+    val optimizedPlan = Optimize.execute(joined.queryExecution.analyzed)
+    assert(optimizedPlan.toString().contains("Generate inline(indexer"))
+    assert(joined.count() === 1)
+
+  }
+
+  test("Broadcast Join preserved under spatial join") {
+    val sqlCtx = this.sqlContext
+    import sqlCtx.implicits._
+    val ring = Array(Point(1.0, 1.0), Point(1.0, -1.0),
+      Point(-1.0, -1.0), Point(-1.0, 1.0),
+      Point(1.0, 1.0))
+    val polygons = sc.parallelize(Seq(
+      ("1", Polygon(Array(0), ring))
+    )).toDF("id", "polygon")
+
+    val points = sc.parallelize(Seq(
+      ("a", 1, Point(0.0, 0.0)),
+      ("b" , 2, Point(2.0, 2.0))
+    )).toDF("name", "value", "point")
+
+    val joined = points.join(broadcast(polygons)).where($"point" within $"polygon")
+    assert(joined.queryExecution.toString() contains "BroadcastExchange")
+
+  }
+}

--- a/src/test/scala/magellan/catalyst/WKTSuite.scala
+++ b/src/test/scala/magellan/catalyst/WKTSuite.scala
@@ -23,8 +23,6 @@ import org.scalatest.FunSuite
 class WKTSuite extends FunSuite with TestSparkContext {
 
   test("convert points to WKT") {
-    val contextLoader = Thread.currentThread().getContextClassLoader
-    Thread.currentThread().setContextClassLoader(getClass.getClassLoader)
     val sqlCtx = this.sqlContext
     import sqlCtx.implicits._
     val df = sc.parallelize(Seq(
@@ -38,6 +36,5 @@ class WKTSuite extends FunSuite with TestSparkContext {
     val point = points.first()(0).asInstanceOf[Point]
     assert(point.getX() === 3.0)
     assert(point.getY() === 15.0)
-    Thread.currentThread().setContextClassLoader(contextLoader)
   }
 }

--- a/src/test/scala/magellan/index/ZOrderCurveSuite.scala
+++ b/src/test/scala/magellan/index/ZOrderCurveSuite.scala
@@ -25,6 +25,17 @@ import org.scalatest.FunSuite
 
 class ZOrderCurveSuite extends FunSuite {
 
+  test("equals") {
+    val indexer = new ZOrderCurveIndexer(BoundingBox(-180, -90, 180, 90))
+    val index = indexer.index(Point(-122.4517249, 37.765315), 5)
+    val anotherIndex = indexer.index(Point(-122.4517249, 37.765315), 5)
+
+    assert(index === anotherIndex)
+    assert(index !== indexer.index(Point(-122.4517249, 37.765315), 7))
+    println(indexer.index(Point(-122.45, 37.76), 25).boundingBox)
+    assert(indexer.index(Point(-122.45, 37.76), 25) !== indexer.index(Point(-122.45, 37.8), 25))
+  }
+
   test("GeoHash globe") {
     val indexer = new ZOrderCurveIndexer(BoundingBox(-180, -90, 180, 90))
     val index = indexer.index(Point(-122.4517249, 37.765315), 5)


### PR DESCRIPTION
This PR uses the recent Spatial Indices PRs #118, #119 to transparently convert a Cross Join with a within filter to use geospatial indices.

The algorithm is as follows:

Given a Logical Query Plan of the form 
'Project [...]
+- Filter Within(point, polygon)
   +- Join Inner
      :- Relation[point, ...] 
      :- Relation[polygon,...]

Convert it into 
'Project [...]
+- Filter Or (('relation == "Within"), Within(point, polygon))
  +- Join Inner JoinKey = 'curve
     :- Generate(Inline(index ($"point" , precision)))
     :- Generate(Inline(index ($"point" , precision)))


The net result of this Query Plan rewrite is that a cross join gets converted to an inner join on the ZOrderCurve and the expensive Within query is further constrained to be evaluated only when the ZOrderCurve enveloping the point is not guaranteed to be within the polygon.

This rewrite can be applied more generally to intersects and other geometric queries with a bit more effort. They will be handled in further PRs.

To use this optimization, run the following initialization step prior to calling Join on the dataframes:

magellan.Utils.injectRules(sparkSession, Map(magellan.index.precision -> ...))
where magellan.index.precision is the number of character precision you need for the geohash (defaults to 30 unless specified)

The PR is also designed to use existing indices. If there is already an index defined on either dataframes, it will be used instead of recomputing the index (sometimes the index creation can be expensive so this optimization allows the index to be created once and reused multiple times during queries)

