### PR TITLE
Remove autoindexing for now, clients can call Utils.injectRules as ne…

### DIFF
--- a/src/main/scala/magellan/SpatialRelation.scala
+++ b/src/main/scala/magellan/SpatialRelation.scala
@@ -36,8 +36,6 @@ private[magellan] trait SpatialRelation extends BaseRelation with PrunedFiltered
 
   private val precision = parameters.getOrElse("magellan.index.precision", "30").toInt
 
-  Utils.injectRules(sqlContext.sparkSession, parameters)
-
   private val indexSchema = ArrayType(new StructType()
     .add("curve", new ZOrderCurveUDT, false)
     .add("relation", StringType, false))


### PR DESCRIPTION
…eded.

 I'm disabling autoindexing for now primarily because always computing the index is not necessarily a good idea, especially if the user doesn;t realize that the default precision is 30 characters which might be too much for their dataset. Better to let the user make this decision for now.
Down the line this should be handled properly by CBO

For now, using spatial joins can be triggered manually by the client code by placing the call
Utils.injectRules(spark, Map(precision -> value)) somewhere prior to the join itself

