### PR TITLE
Fix Issue-97: Large shapefiles can cause int overflow

### DIFF
--- a/src/main/scala/magellan/mapreduce/ShapefileReader.scala
+++ b/src/main/scala/magellan/mapreduce/ShapefileReader.scala
@@ -32,11 +32,11 @@ private[magellan] class ShapefileReader extends RecordReader[ShapeKey, ShapeWrit
 
   private var dis: DataInputStream = _
 
-  private var length: Int = _
+  private var length: BigInt = _
 
-  private var remaining: Int = _
+  private var remaining: BigInt = _
 
-  override def getProgress: Float = remaining / length.toFloat
+  override def getProgress: Float = remaining.toFloat / length.toFloat
 
   override def nextKeyValue(): Boolean = {
     if (remaining <= 0) {
@@ -70,7 +70,8 @@ private[magellan] class ShapefileReader extends RecordReader[ShapeKey, ShapeWrit
     // skip the next 20 bytes which should all be zero
     0 until 5 foreach {_ => require(is.readInt() == 0)}
     // file length in bits
-    length = 16 * is.readInt() - 50 * 16
+    val i: BigInt = is.readInt()
+    length = 16 * i - 50 * 16
     remaining = length
     val version = EndianUtils.swapInteger(is.readInt())
     require(version == 1000)


### PR DESCRIPTION
Wasn;t able to find a way to push large shapefiles to git (LFS doesn't seem to work nicely for Open Source Projects), so verified manually by downloading osgeo and a sample shapefile from https://www.census.gov/cgi-bin/geo/shapefiles/index.php (NY, Census Blocks)

=====================================================================
Steps to reproduce:
bin/spark-shell --master local[1] --driver-memory 4G  --jars ${path.to.magellan.jar}

Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 2.2.0
      /_/
         
Using Scala version 2.11.8 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_111)
Type in expressions to have them evaluated.
Type :help for more information.

scala> val df = spark.read.format("magellan").load("$path")
df: org.apache.spark.sql.DataFrame = [point: point, polyline: polyline ... 4 more fields]

scala> df.count()
res0: Long = 350169

=================================================================
to verify using osgeo (Python) :

from  osgeo import ogr, osr

driver = ogr.GetDriverByName('ESRI Shapefile')
shp = driver.Open(r'$path')

# Get Projection from layer
layer = shp.GetLayer()

layer.GetFeatureCount()
350169



