### PR TITLE
Dynamically configure precision

### DIFF
--- a/src/main/scala/magellan/catalyst/SpatialJoinHint.scala
+++ b/src/main/scala/magellan/catalyst/SpatialJoinHint.scala
@@ -14,17 +14,24 @@
   * limitations under the License.
   */
 
-package magellan
+package magellan.catalyst
 
-import magellan.catalyst.SpatialJoin
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.internal.SQLConf
 
-object Utils {
+/**
+  * A Spatial Join Hint node.
+  */
+case class SpatialJoinHint(child: LogicalPlan, hints: Map[String, String])
+  extends UnaryNode {
 
-  def injectRules(session: SparkSession): Unit = {
-    if (!session.experimental.extraOptimizations.exists(_.isInstanceOf[SpatialJoin])) {
-      session.experimental.extraOptimizations ++= (Seq(SpatialJoin(session)))
-    }
+  override def output: Seq[Attribute] = child.output
+
+  override lazy val canonicalized: LogicalPlan = child.canonicalized
+
+  override def computeStats(conf: SQLConf): Statistics = {
+    val stats = child.stats(conf)
+    stats.copy()
   }
-
 }

--- a/src/main/scala/magellan/catalyst/SpatialJoinHint.scala
+++ b/src/main/scala/magellan/catalyst/SpatialJoinHint.scala
@@ -18,7 +18,6 @@ package magellan.catalyst
 
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.internal.SQLConf
 
 /**
   * A Spatial Join Hint node.
@@ -28,10 +27,5 @@ case class SpatialJoinHint(child: LogicalPlan, hints: Map[String, String])
 
   override def output: Seq[Attribute] = child.output
 
-  override lazy val canonicalized: LogicalPlan = child.canonicalized
-
-  override def computeStats(conf: SQLConf): Statistics = {
-    val stats = child.stats(conf)
-    stats.copy()
-  }
+  override lazy val canonicalized: LogicalPlan = SpatialJoinHint(child, hints)
 }

--- a/src/main/scala/magellan/dsl/package.scala
+++ b/src/main/scala/magellan/dsl/package.scala
@@ -17,10 +17,10 @@
 package org.apache.spark.sql.magellan
 
 import magellan.Point
-import org.apache.spark.sql.Column
+import magellan.catalyst.SpatialJoinHint
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.{Column, Dataset}
 
 package object dsl {
 
@@ -51,8 +51,16 @@ package object dsl {
 
     implicit def wkt(x: Column) = Column(WKT(x.expr))
 
-  }
+    implicit class DslDataset[T](c: Dataset[T]) {
+      def df: Dataset[T] = c
 
+      def index(precision: Int): Dataset[T] = {
+        Dataset[T](df.sparkSession,
+          SpatialJoinHint(df.logicalPlan, Map("magellan.index.precision" -> precision.toString)))(df.exprEnc)
+      }
+    }
+
+  }
 
   object expressions extends ExpressionConversions  // scalastyle:ignore
 


### PR DESCRIPTION
There are use cases where within the same Spark run (ie with the same spark context) we want to join multiple different spatial datasets at different resolutions.
This PR allows you to pass in the resolution as a hint as follows:

import org.apache.spark.sql.magellan.dsl.expressions._ 
point.join(polygons index 15).where($"point" within $"polygon")

allows you to pass a hint to the optimizer that the index resolution should be set to 15.

also, modifies injectRules to pass in only the spark session and not the parameters.
ie. use injectRules(spark) instead of injectRules(spark, Map(...))

Future enhancements:
- [ ] Ability to pass in a min/ max precision to greedily cover the geometries?
- [ ] Ability to index geometries at the right precision on the fly? 