### PR TITLE
Range Query: Shape within Rectangle

### DIFF
--- a/src/main/scala/magellan/BoundingBox.scala
+++ b/src/main/scala/magellan/BoundingBox.scala
@@ -50,7 +50,7 @@ case class BoundingBox(xmin: Double, ymin: Double, xmax: Double, ymax: Double) {
     !(otherxmin >= xmax || otherymin >= ymax || otherymax <= ymin || otherxmax <= xmin)
   }
 
-  private [magellan] def contains(other: BoundingBox): Boolean = {
+  def contains(other: BoundingBox): Boolean = {
     val BoundingBox(otherxmin, otherymin, otherxmax, otherymax) = other
     (xmin <= otherxmin && ymin <= otherymin && xmax >= otherxmax && ymax >= otherymax)
   }
@@ -60,7 +60,7 @@ case class BoundingBox(xmin: Double, ymin: Double, xmax: Double, ymax: Double) {
     (otherxmin > xmax || otherxmax < xmin || otherymin > ymax || otherymax < ymin)
   }
 
-  private [magellan] def contains(point: Point): Boolean = {
+  def contains(point: Point): Boolean = {
     val (x, y) = (point.getX(), point.getY())
     (xmin <= x && ymin <= y && xmax >= x && ymax >= y)
   }

--- a/src/main/scala/magellan/dsl/package.scala
+++ b/src/main/scala/magellan/dsl/package.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.magellan
 
-import magellan.Point
+import magellan.{BoundingBox, Point}
 import magellan.catalyst.SpatialJoinHint
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types._
@@ -44,6 +44,8 @@ package object dsl {
       def index(precision: Int): Column = Column(Indexer(c.expr, precision))
 
       def wkt(): Column = Column(WKT(c.expr))
+
+      def withinRange(boundingBox: BoundingBox): Column = Column(PointInRange(c.expr, boundingBox))
 
     }
     

--- a/src/main/scala/org/apache/spark/sql/types/expressions.scala
+++ b/src/main/scala/org/apache/spark/sql/types/expressions.scala
@@ -1,0 +1,79 @@
+/**
+  * Copyright 2015 Ram Sriharsha
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package org.apache.spark.sql.types
+
+import magellan.BoundingBox
+import magellan.catalyst.MagellanExpression
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
+import org.apache.spark.sql.catalyst.expressions.{Expression, UnaryExpression}
+
+/**
+  * A function that returns true if the Shape defined by the child expression
+  * lies within the bounding box.
+  *
+  * @param child
+  * @param boundingBox
+  */
+case class PointInRange(child: Expression, boundingBox: BoundingBox)
+  extends UnaryExpression with MagellanExpression {
+
+  override def dataType: DataType = BooleanType
+
+  override def nullable: Boolean = child.nullable
+
+  override def nullSafeEval(leftEval: Any): Any = {
+    val leftRow = leftEval.asInstanceOf[InternalRow]
+
+    // check if the bounding box contains the child's bounding box.
+    val ((lxmin, lymin), (lxmax, lymax)) = (
+      (leftRow.getDouble(1), leftRow.getDouble(2)),
+      (leftRow.getDouble(3), leftRow.getDouble(4))
+    )
+
+    val childBoundingBox = BoundingBox(lxmin, lymin, lxmax, lymax)
+
+    boundingBox.contains(childBoundingBox)
+  }
+
+  override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val lxminVar = ctx.freshName("lxmin")
+    val lyminVar = ctx.freshName("lymin")
+    val lxmaxVar = ctx.freshName("lxmax")
+    val lymaxVar = ctx.freshName("lymax")
+
+    val ltypeVar = ctx.freshName("ltype")
+
+
+    val idx = ctx.references.length
+    ctx.addReferenceObj("boundingBox", boundingBox)
+
+    val boundingBoxVar = ctx.freshName("boundingBox")
+    val otherBoundingBoxVar = ctx.freshName("boundingBox")
+
+    nullSafeCodeGen(ctx, ev, c1 => {
+        s"" +
+        s"Double $lxminVar = $c1.getDouble(1);" +
+        s"Double $lyminVar = $c1.getDouble(2);" +
+        s"Double $lxmaxVar = $c1.getDouble(3);" +
+        s"Double $lymaxVar = $c1.getDouble(4);" +
+        s"magellan.BoundingBox $boundingBoxVar = (magellan.BoundingBox)references[$idx];" +
+        s"magellan.BoundingBox $otherBoundingBoxVar = new magellan.BoundingBox($lxminVar, $lyminVar, $lxmaxVar, $lymaxVar);" +
+        s"${ev.value} = $boundingBoxVar.contains($otherBoundingBoxVar);"
+    })
+  }
+}

--- a/src/test/scala/magellan/TestingUtils.scala
+++ b/src/test/scala/magellan/TestingUtils.scala
@@ -19,6 +19,10 @@ package magellan
 import com.esri.core.geometry.{Point => ESRIPoint, Polygon => ESRIPolygon, Polyline => ESRIPolyLine}
 import com.google.common.base.Splitter
 import magellan.geometry.{Loop, R2Loop}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.LeafExpression
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.types.{PointUDT, PolygonUDT}
 import org.scalatest.exceptions.TestFailedException
 
 import scala.collection.JavaConversions._
@@ -211,5 +215,27 @@ object TestingUtils {
     val r2Loop = new R2Loop()
     r2Loop.init(xcoordinates, ycoordinates, 0, size - 1)
     r2Loop
+  }
+}
+
+case class MockPointExpr(point: Point) extends LeafExpression with CodegenFallback {
+
+  override def nullable: Boolean = false
+
+  override val dataType = new PointUDT
+
+  override def eval(input: InternalRow): Any = {
+    dataType.serialize(point)
+  }
+}
+
+case class MockPolygonExpr(polygon: Polygon) extends LeafExpression with CodegenFallback {
+
+  override def nullable: Boolean = false
+
+  override val dataType = new PolygonUDT
+
+  override def eval(input: InternalRow): Any = {
+    dataType.serialize(polygon)
   }
 }

--- a/src/test/scala/magellan/catalyst/TransformerSuite.scala
+++ b/src/test/scala/magellan/catalyst/TransformerSuite.scala
@@ -17,8 +17,11 @@
 package magellan.catalyst
 
 import magellan.TestingUtils._
-import magellan.{Point, TestSparkContext}
+import magellan.{MockPointExpr, Point, TestSparkContext}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.magellan.dsl.expressions._
+import org.apache.spark.sql.types.Transformer
 import org.scalatest.FunSuite
 
 
@@ -35,5 +38,14 @@ class TransformerSuite extends FunSuite with TestSparkContext {
       .first()(0).asInstanceOf[Point]
 
     assert(point.getX() ~== -199.0 absTol 1.0)
+  }
+
+  test("eval: transform") {
+    val fn = (p: Point) => Point(2 * p.getX(), 2 * p.getY())
+    val expr = Transformer(MockPointExpr(Point(1.0, 2.0)), fn)
+    val result = expr.eval(null).asInstanceOf[InternalRow]
+    // skip the type
+    assert(result.getDouble(1) === 2.0)
+    assert(result.getDouble(2) === 4.0)
   }
 }


### PR DESCRIPTION
Support for calculating whether a shape is within a Bounding Box
e.g, points.where($"point" withinRange BoundingBox(xmin, ymin, xmax, ymax))

Additional tests for codegen fallback