### PR TITLE
Issue #183 - Support Parsing of MultiPolygon in WKT Format

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalaVersion := "2.11.8"
 
 crossScalaVersions := Seq("2.11.8")
 
-sparkVersion := "2.2.0"
+sparkVersion := "2.2.1"
 
 scalacOptions += "-optimize"
 

--- a/src/main/scala/magellan/WKTParser.scala
+++ b/src/main/scala/magellan/WKTParser.scala
@@ -23,76 +23,136 @@ import scala.collection.mutable.ListBuffer
 
 object WKTParser {
 
-  def whitespace: P[String] = P(" ") map {_.toString}
+  def whitespace: P[String] = P(" ") map {
+    _.toString
+  }
 
-  val posInt: P[String] = P(CharIn('0'to'9').rep(1).!)
+  val posInt: P[String] = P(CharIn('0' to '9').rep(1).!)
 
-  val negInt: P[String] = P("-" ~ posInt) map {"-" + _}
+  val negInt: P[String] = P("-" ~ posInt) map {
+    "-" + _
+  }
 
   val int: P[String] = P(posInt | negInt)
 
-  val float: P[String] = P(int ~ P(".") ~ posInt) map { case (x , y) => (x + "." + y)}
+  val float: P[String] = P(int ~ P(".") ~ posInt) map { case (x, y) => (x + "." + y) }
 
-  val number = P(float | int) map {_.toDouble}
+  val number = P(float | int) map {
+    _.toDouble
+  }
 
-  def point0: P[String] = P("""POINT""") map {_.toString}
+  def multi0: P[String] = P("""MULTI""") map {
+    _.toString
+  }
 
-  def empty0: P[String] = P("""EMPTY""") map {_.toString}
+  def point0: P[String] = P("""POINT""") map {
+    _.toString
+  }
 
-  def comma: P[String] = P(",") map {_.toString}
+  def empty0: P[String] = P("""EMPTY""") map {
+    _.toString
+  }
 
-  def leftBrace: P[String] = P("(") map {_.toString}
+  def comma: P[String] = P(",") map {
+    _.toString
+  }
 
-  def rightBrace: P[String] = P(")") map {_.toString}
+  def leftBrace: P[String] = P("(") map {
+    _.toString
+  }
 
-  def coords: P[Point] =  P(number ~ whitespace ~ number) map {
+  def rightBrace: P[String] = P(")") map {
+    _.toString
+  }
+
+  def coords: P[Point] = P(number ~ whitespace ~ number) map {
     case (x, _, y) => Point(x, y)
   }
 
   def ring: P[Array[Point]] = P(leftBrace ~ coords.rep(1, (comma ~ whitespace | comma)) ~ rightBrace) map {
-    case (_, x ,_) => x.toArray
+    case (_, x, _) => x.toArray
   }
 
-  def point: P[Point] = P(point0 ~ whitespace.? ~ leftBrace ~ coords ~ rightBrace) map {
-    case (_ , _, _, p, _) => p
+  def pointCoords: P[Point] = P(leftBrace ~ coords ~ rightBrace) map {
+    case (_, x, _) => x
   }
 
-  def pointEmpty: P[Shape] = P(point0 ~ whitespace ~ empty0) map {_ => NullShape}
+  def point: P[Point] = P(point0 ~ whitespace.? ~ pointCoords) map {
+    case (_, _, p) => p
+  }
 
-  def linestring0: P[String] = P("""LINESTRING""") map {_.toString}
+  def multipoint: P[Array[Point]] = P(multi0 ~ point0 ~ whitespace.? ~ leftBrace ~ (pointCoords.rep(1, (comma ~ whitespace | comma)) | coords.rep(1, (comma ~ whitespace | comma))) ~ rightBrace) map {
+    case (_, _, _, _, p, _) => p.toArray
+  }
+
+  def pointEmpty: P[Shape] = P(point0 ~ whitespace ~ empty0) map { _ => NullShape }
+
+  def linestring0: P[String] = P("""LINESTRING""") map {
+    _.toString
+  }
 
   def linestring: P[PolyLine] = P(linestring0 ~ whitespace.? ~ ring) map {
-    case (_ , _, x) => PolyLine(Array(0), x)
+    case (_, _, x) => PolyLine(Array(0), x)
   }
 
-  def polygon0: P[String] = P("""POLYGON""") map {_.toString}
-
-  def polygonWithoutHoles: P[Polygon] =
-    P(polygon0 ~ whitespace.? ~ P("((") ~ coords.rep(1, (comma ~ whitespace | comma)) ~ P("))")) map {
-    case (_ , _, x ) => Polygon(Array(0), x.toArray)
+  def multilinestring: P[Array[PolyLine]] = P(multi0 ~ linestring0 ~ whitespace.? ~ leftBrace ~ ring.rep(1, (comma ~ whitespace | comma)) ~ rightBrace) map {
+    case (_, _, _, _, p, _) => p.map(points => PolyLine(Array(0), points)).toArray
   }
 
-  def polygonWithHoles: P[Polygon] =
-    P(polygon0 ~ whitespace.? ~ P("(") ~ ring.rep(1, (comma ~ whitespace | comma)) ~ P(")")) map {
-    case (_ , _, x) =>
-      val indices = ListBuffer[Int]()
-      val points = ListBuffer[Point]()
-      var prev = 0
-      var i = 0
-      val numRings = x.size
-      while (i < numRings) {
-        indices.+= (prev)
-        prev += x(i).length
-        points.++=(x(i))
-        i += 1
-      }
-      Polygon(indices.toArray, points.toArray)
+  def polygon0: P[String] = P("""POLYGON""") map {
+    _.toString
   }
 
-  def expr: P[Shape] = P(point | pointEmpty | linestring | polygonWithoutHoles | polygonWithHoles ~ End)
+  def polygonWithoutHoles: P[Polygon] = polygon
+
+
+  def polygonWithHoles: P[Polygon] = polygon
+
+  def polygon: P[Polygon] =
+    P(polygon0 ~ whitespace.? ~ polygonCoords) map {
+      case (_, _, x) => x
+    }
+
+  def polygonCoords: P[Polygon] =
+    P(P("(") ~ ring.rep(1, (comma ~ whitespace | comma)) ~ P(")")) map {
+      case (x) =>
+        val indices = ListBuffer[Int]()
+        val points = ListBuffer[Point]()
+        var prev = 0
+        var i = 0
+        val numRings = x.size
+        while (i < numRings) {
+          indices.+=(prev)
+          prev += x(i).length
+          points.++=(x(i))
+          i += 1
+        }
+        Polygon(indices.toArray, points.toArray)
+    }
+
+
+  def multipolygon: P[Array[Polygon]] = P(multi0 ~ polygon0 ~ whitespace.? ~ leftBrace ~ polygonCoords.rep(1, (comma ~ whitespace | comma)) ~ rightBrace) map {
+    case (_, _, _, _, p, _) => p.toArray
+  }
+
+  def expr: P[Shape] = P(point | pointEmpty | linestring | polygon ~ End)
+
+  def singleShapeArray: P[Array[Shape]] = P(point | pointEmpty | linestring | polygon) map {
+    case (p) => Array(p)
+  }
+
+
+  def exprArray: P[Array[_ <: Shape]] = P(singleShapeArray | multipoint | multilinestring | multipolygon ~ End)
 
   def parseAll(text: String): Shape = {
     expr.parse(text) match {
+      case Success(value, _) => value
+      case Failure(parser, index, stack) => throw new RuntimeException(stack.toString)
+    }
+  }
+
+  def parseAllArray(text: String): Array[_ <: Shape] = {
+    exprArray.parse(text) match {
       case Success(value, _) => value
       case Failure(parser, index, stack) => throw new RuntimeException(stack.toString)
     }

--- a/src/main/scala/magellan/dsl/package.scala
+++ b/src/main/scala/magellan/dsl/package.scala
@@ -48,10 +48,12 @@ package object dsl {
 
       def withinRange(origin: Point, radius: Double): Column = Column(WithinCircleRange(c.expr, origin, radius))
     }
-    
+
     implicit def point(x: Column, y: Column) = Column(PointConverter(x.expr, y.expr))
 
     implicit def wkt(x: Column) = Column(WKT(x.expr))
+
+    implicit def wktArray(x: Column) = Column(WKTArray(x.expr))
 
     implicit class DslDataset[T](c: Dataset[T]) {
       def df: Dataset[T] = c

--- a/src/test/scala/magellan/WKTParserSuite.scala
+++ b/src/test/scala/magellan/WKTParserSuite.scala
@@ -45,6 +45,14 @@ class WKTParserSuite extends FunSuite {
     assert(p.getY() === 10.0)
   }
 
+  test("parse empty point") {
+    val parsed = WKTParser.pointEmpty.parse("POINT EMPTY")
+    assert(parsed.index == 11)
+    val p = parsed.get.value
+    assert(p === NullShape)
+
+  }
+
   test("parse multipoint, single value") {
     val parsed = WKTParser.multipoint.parse("MULTIPOINT (30 10)")
     assert(parsed.index == 18)
@@ -168,7 +176,6 @@ class WKTParserSuite extends FunSuite {
     assert(p(1).getVertex(5) === Point(20.0, 30.0))
   }
 
-
   test("parse") {
     val shape = WKTParser.parseAll("LINESTRING (30 10, 10 30, 40 40)")
     assert(shape.isInstanceOf[PolyLine])
@@ -185,6 +192,29 @@ class WKTParserSuite extends FunSuite {
     assert(shape.length === 2)
     assert(shape(0).isInstanceOf[PolyLine])
     assert(shape(1).isInstanceOf[PolyLine])
+  }
+
+  test("parse failure") {
+    try {
+      WKTParser.parseAll("MULTILINESTRING ((30 10, 10 30, 40 40),30 10, 10 30, 40 40)")
+      fail()
+    }
+    catch {
+      case _: RuntimeException => // Expected, so continue
+    }
+
+  }
+
+
+  test("parse array failure") {
+    try {
+      WKTParser.parseAll("LINESTRING (30 10, (10 30), 40 40)")
+      fail()
+    }
+    catch {
+      case _: RuntimeException => // Expected, so continue
+    }
+
   }
 
   test("perf") {


### PR DESCRIPTION
I was unable to find a way to keep the current functionality backward compatible with Multi point WKT.

Because of this I have added a new "wktArray" function. This will parse all forms of WKT and output the result(s) in an array. It will then be up to the end user to explode the array to get a row per point.

the two lines below will output the same point data, however the second will support multipoint and therefore may create multiple rows.

`wkt($"text")("point")` 

`explode(wktArray($"text")("point"))` 