### PR TITLE
Add Encoders for Magellan Data Types

### DIFF
--- a/src/main/scala/magellan/PolyLine.scala
+++ b/src/main/scala/magellan/PolyLine.scala
@@ -55,9 +55,9 @@ class PolyLine extends Shape {
     val offsets = indices.zip(indices.drop(1) ++ Array(xcoordinates.length))
     for ((start, end) <- offsets) {
       curves += ({
-        val curves = new R2Loop()
-        curves.init(xcoordinates, ycoordinates, start, end - 1)
-        curves
+        val curve = new R2Loop()
+        curve.init(xcoordinates, ycoordinates, start, end - 1)
+        curve
       })
     }
   }
@@ -166,12 +166,11 @@ class PolyLine extends Shape {
     ???
   }
 
-  /*override def jsonValue: JValue =
-    ("type" -> "udt") ~
-      ("class" -> this.getClass.getName) ~
-      ("pyClass" -> "magellan.types.PolyLineUDT") ~
-      ("indices" -> JArray(indices.map(index => JInt(index)).toList)) ~
-      ("points" -> JArray(points.map(_.jsonValue).toList))*/
+  def readResolve(): AnyRef = {
+    curves = new ArrayBuffer[Curve]()
+    this.init(indices, xcoordinates, ycoordinates, boundingBox)
+    this
+  }
 }
 
 object PolyLine {

--- a/src/main/scala/magellan/encoders/Encoders.scala
+++ b/src/main/scala/magellan/encoders/Encoders.scala
@@ -1,0 +1,56 @@
+package magellan.encoders
+
+import magellan._
+import org.apache.spark.sql.Encoder
+import org.apache.spark.sql.catalyst.analysis.GetColumnByOrdinal
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.types._
+
+import scala.reflect._
+
+object Encoders {
+
+  implicit def encoderForPoint: Encoder[Point] = {
+    val sqlType = new PointUDT().sqlType
+    ExpressionEncoder[Point](
+      schema = sqlType,
+      flat = true,
+      serializer = Seq(
+        MagellanSerializer(
+          BoundReference(0, ObjectType(classOf[Point]), nullable = true), sqlType)),
+      deserializer =
+        MagellanDeserializer(
+          GetColumnByOrdinal(0, sqlType), classOf[Point]),
+      clsTag = classTag[Point])
+  }
+
+  implicit def encoderForPolygon: Encoder[Polygon] = {
+    val sqlType = new PolygonUDT().sqlType
+    ExpressionEncoder[Polygon](
+      schema = sqlType,
+      flat = true,
+      serializer = Seq(
+        MagellanSerializer(
+          BoundReference(0, ObjectType(classOf[Polygon]), nullable = true), sqlType)),
+      deserializer =
+        MagellanDeserializer(
+          GetColumnByOrdinal(0, sqlType), classOf[Polygon]),
+      clsTag = classTag[Polygon])
+  }
+
+  implicit def encoderForPolyLine: Encoder[PolyLine] = {
+    val sqlType = new PolyLineUDT().sqlType
+    ExpressionEncoder[PolyLine](
+      schema = sqlType,
+      flat = true,
+      serializer = Seq(
+        MagellanSerializer(
+          BoundReference(0, ObjectType(classOf[PolyLine]), nullable = true), sqlType)),
+      deserializer =
+        MagellanDeserializer(
+          GetColumnByOrdinal(0, sqlType), classOf[PolyLine]),
+      clsTag = classTag[PolyLine])
+  }
+
+}

--- a/src/main/scala/org/apache/spark/sql/catalyst/expressions/serdes.scala
+++ b/src/main/scala/org/apache/spark/sql/catalyst/expressions/serdes.scala
@@ -1,0 +1,42 @@
+package org.apache.spark.sql.catalyst.expressions
+
+import magellan._
+import magellan.catalyst.MagellanExpression
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.types._
+
+
+case class MagellanSerializer(
+    override val child: Expression,
+    _dataType: DataType)
+  extends UnaryExpression
+  with MagellanExpression
+  with CodegenFallback
+  with NonSQLExpression {
+
+  override def nullable: Boolean = false
+
+  override protected def nullSafeEval(input: Any): Any = {
+    val shape = input.asInstanceOf[Shape]
+    serialize(shape)
+  }
+
+  override def dataType: DataType = _dataType
+}
+
+case class MagellanDeserializer(
+    override val child: Expression, klass: Class[_ <: Shape])
+  extends UnaryExpression
+  with MagellanExpression
+  with CodegenFallback
+  with NonSQLExpression {
+
+  override def nullable: Boolean = false
+
+  override protected def nullSafeEval(input: Any): Any = {
+    newInstance(input.asInstanceOf[InternalRow])
+  }
+
+  override def dataType: DataType = ObjectType(klass)
+}

--- a/src/main/scala/org/apache/spark/sql/types/PointUDT.scala
+++ b/src/main/scala/org/apache/spark/sql/types/PointUDT.scala
@@ -6,7 +6,7 @@ import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 
 class PointUDT extends UserDefinedType[Point] with GeometricUDT {
 
-  override val sqlType: DataType = StructType(
+  override val sqlType: StructType = StructType(
     Seq(
       StructField("type", IntegerType, nullable = false),
       StructField("xmin", DoubleType, nullable = false),

--- a/src/main/scala/org/apache/spark/sql/types/PolyLineUDT.scala
+++ b/src/main/scala/org/apache/spark/sql/types/PolyLineUDT.scala
@@ -6,7 +6,7 @@ import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 
 class PolyLineUDT extends UserDefinedType[PolyLine] with GeometricUDT {
 
-  override val sqlType: DataType = StructType(
+  override val sqlType: StructType = StructType(
     Seq(
       StructField("type", IntegerType, nullable = false),
       StructField("xmin", DoubleType, nullable = false),

--- a/src/main/scala/org/apache/spark/sql/types/PolygonUDT.scala
+++ b/src/main/scala/org/apache/spark/sql/types/PolygonUDT.scala
@@ -6,7 +6,7 @@ import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 
 class PolygonUDT extends UserDefinedType[Polygon] with GeometricUDT {
 
-  override val sqlType: DataType = StructType(Seq(
+  override val sqlType: StructType = StructType(Seq(
     StructField("type", IntegerType, nullable = false),
     StructField("xmin", DoubleType, nullable = false),
     StructField("ymin", DoubleType, nullable = false),

--- a/src/test/scala/magellan/PolygonSuite.scala
+++ b/src/test/scala/magellan/PolygonSuite.scala
@@ -15,7 +15,7 @@
  */
 package magellan
 
-import com.esri.core.geometry.{GeometryEngine, Point => ESRIPoint, Polygon => ESRIPolygon, Polyline => ESRIPolyline}
+import com.esri.core.geometry.{GeometryEngine, Point => ESRIPoint, Polyline => ESRIPolyline}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import magellan.TestingUtils._

--- a/src/test/scala/magellan/ShapefileSuite.scala
+++ b/src/test/scala/magellan/ShapefileSuite.scala
@@ -17,8 +17,6 @@
 package magellan
 
 import magellan.TestingUtils._
-import org.apache.spark.SparkConf
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.magellan.dsl.expressions._
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 

--- a/src/test/scala/magellan/encoders/EncodersSuite.scala
+++ b/src/test/scala/magellan/encoders/EncodersSuite.scala
@@ -1,0 +1,82 @@
+package magellan.encoders
+
+import magellan.{Point, PolyLine, Polygon, TestSparkContext}
+import magellan.encoders.Encoders._
+import org.apache.spark.sql.magellan.dsl.expressions._
+import org.scalatest.FunSuite
+
+class EncodersSuite extends FunSuite with TestSparkContext {
+
+  test("point encoder") {
+    val sqlContext = this.sqlContext
+    import sqlContext.implicits._
+    val points = sc.parallelize(Seq(
+      Point(-1.0, -0.9),
+      Point(1.1, -0.8),
+      Point(1.2, 0.9),
+      Point(-0.8, 0.9)
+    )).toDS()
+
+    assert(points.filter(_.getX() == -1.0).count() === 1)
+  }
+
+  test("polygon encoder") {
+    val sqlContext = this.sqlContext
+    import sqlContext.implicits._
+    val ring1 = Array(Point(1.0, 1.0), Point(1.0, -1.0),
+      Point(-1.0, -1.0), Point(-1.0, 1.0), Point(1.0, 1.0))
+
+    val ring2 = Array(Point(5.0, 5.0), Point(5.0, 4.0),
+      Point(4.0, 4.0), Point(4.0, 5.0), Point(5.0, 5.0))
+
+    val polygon1 = Polygon(Array(0),ring1)
+    val polygon2 = Polygon(Array(0), ring2)
+
+    val polygons = sc.parallelize(Seq(
+      polygon1,
+      polygon2)).toDS()
+
+    assert(polygons.filter(_.contains(Point(0.0, 0.0))).count() === 1)
+  }
+
+  test("join") {
+    val sqlContext = this.sqlContext
+    import sqlContext.implicits._
+
+    val ring1 = Array(Point(1.0, 1.0), Point(1.0, -1.0),
+      Point(-1.0, -1.0), Point(-1.0, 1.0), Point(1.0, 1.0))
+
+    val ring2 = Array(Point(5.0, 5.0), Point(5.0, 4.0),
+      Point(4.0, 4.0), Point(4.0, 5.0), Point(5.0, 5.0))
+
+    val polygon1 = Polygon(Array(0),ring1)
+    val polygon2 = Polygon(Array(0), ring2)
+
+    val polygons = sc.parallelize(Seq(
+      polygon1,
+      polygon2)).toDS()
+
+    val points = sc.parallelize(Seq(
+      Point(0.0, 0.0),
+      Point(1.1, 1.1),
+      Point(4.4, 4.4)
+    )).toDS()
+
+    val joined = points.join(polygons,
+      points.col("type") within polygons.col("type"))
+
+    assert(joined.count() === 2)
+  }
+
+  test("polyline encoder") {
+    val sqlContext = this.sqlContext
+    import sqlContext.implicits._
+
+    val ring = Array(Point(-1.0, 1.0), Point(1.0, 1.0),
+      Point(1.0, -1.0), Point(-1.0, -1.0))
+    val polyline = PolyLine(Array(0), ring)
+    val polylines = sc.parallelize(Seq(polyline)).toDS()
+
+    assert(polylines.filter(_.getVertex(0) == Point(-1.0, 1.0)).count() === 1)
+  }
+}


### PR DESCRIPTION
This PR adds support for Encoders for Magellan Data Types

- [x] Point
- [x] Polygon
- [x] PolyLine
- [ ] Codegen the Serialization/ Deserialization expressions

Currently we use codegen fallback and only support evaluated mode
A subsequent PR will add support for codegen

Usage:
```scala
import magellan.encoders.Encoders._
import sqlContext.implicits._
val points = sc.parallelize(Seq(
      Point(-1.0, -0.9),
      Point(1.1, -0.8),
      Point(1.2, 0.9),
      Point(-0.8, 0.9)
    )).toDS()

points.filter(_.getX() == -1.0) 
```