### PR TITLE
Spark 2.3.1 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
   include: 
     - jdk: oraclejdk8 
       scala: 2.11.8
-      env: TEST_HADOOP_VERSION="2.7.3" TEST_SPARK_VERSION="2.2.0"
+      env: TEST_HADOOP_VERSION="2.7.3" TEST_SPARK_VERSION="2.3.1"
     - jdk: oraclejdk8
       scala: 2.11.8
       env: TEST_HADOOP_VERSION="2.2.0" TEST_SPARK_VERSION="2.1.0"

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalaVersion := "2.11.8"
 
 crossScalaVersions := Seq("2.11.8")
 
-sparkVersion := "2.2.0"
+sparkVersion := "2.3.1"
 
 scalacOptions += "-optimize"
 

--- a/src/main/scala/magellan/catalyst/SpatialJoin.scala
+++ b/src/main/scala/magellan/catalyst/SpatialJoin.scala
@@ -97,8 +97,8 @@ private[magellan] case class SpatialJoin(session: SparkSession)
             .fold[Expression](Indexer(rightProjection, precision))(identity)
 
           val join = Join(
-            Generate(Inline(leftIndexer), true, false, None, Seq(c1, r1), l),
-            Generate(Inline(rightIndexer), true, false, None, Seq(c2, r2), r),
+            Generate(Inline(leftIndexer), Nil, false, None, Seq(c1, r1), l),
+            Generate(Inline(rightIndexer), Nil, false, None, Seq(c2, r2), r),
             joinType,
             Some(And(EqualTo(c1, c2), transformedCondition)))
 

--- a/src/main/scala/magellan/catalyst/SpatialJoinHint.scala
+++ b/src/main/scala/magellan/catalyst/SpatialJoinHint.scala
@@ -27,5 +27,5 @@ case class SpatialJoinHint(child: LogicalPlan, hints: Map[String, String])
 
   override def output: Seq[Attribute] = child.output
 
-  override lazy val canonicalized: LogicalPlan = SpatialJoinHint(child, hints)
+  override def doCanonicalize(): LogicalPlan = SpatialJoinHint(child, hints)
 }

--- a/src/main/scala/org/apache/spark/sql/catalyst/expressions/functions.scala
+++ b/src/main/scala/org/apache/spark/sql/catalyst/expressions/functions.scala
@@ -48,8 +48,8 @@ case class PointConverter(
   }
 
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    ctx.addMutableState(classOf[PointUDT].getName, "pointUDT", "pointUDT = new org.apache.spark.sql.types.PointUDT();")
-    defineCodeGen(ctx, ev, (c1, c2) => s"pointUDT.serialize($c1, $c2)")
+    val pnt = ctx.addMutableState(classOf[PointUDT].getName, "pointUDT", v => s"$v = new org.apache.spark.sql.types.PointUDT();")
+    defineCodeGen(ctx, ev, (c1, c2) => s"$pnt.serialize($c1, $c2)")
   }
 }
 
@@ -68,14 +68,12 @@ case class Transformer(
   override def dataType: DataType = child.dataType
 
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    val serializersVar = ctx.freshName("serializers")
-
-    ctx.addMutableState(classOf[java.util.HashMap[Integer, UserDefinedType[Shape]]].getName, s"$serializersVar",
-      s"$serializersVar = new java.util.HashMap<Integer, org.apache.spark.sql.types.UserDefinedType<magellan.Shape>>() ;" +
-        s"$serializersVar.put(1, new org.apache.spark.sql.types.PointUDT());" +
-        s"$serializersVar.put(2, new org.apache.spark.sql.types.LineUDT());" +
-        s"$serializersVar.put(3, new org.apache.spark.sql.types.PolyLineUDT());" +
-        s"$serializersVar.put(5, new org.apache.spark.sql.types.PolygonUDT());" +
+    val serializersVar = ctx.addMutableState(classOf[java.util.HashMap[Integer, UserDefinedType[Shape]]].getName, "serializers",
+      v =>s"$v = new java.util.HashMap<Integer, org.apache.spark.sql.types.UserDefinedType<magellan.Shape>>() ;" +
+        s"$v.put(1, new org.apache.spark.sql.types.PointUDT());" +
+        s"$v.put(2, new org.apache.spark.sql.types.LineUDT());" +
+        s"$v.put(3, new org.apache.spark.sql.types.PolyLineUDT());" +
+        s"$v.put(5, new org.apache.spark.sql.types.PolygonUDT());" +
         "")
 
     val shapeVar = ctx.freshName("shape")
@@ -111,14 +109,12 @@ case class WKT(override val child: Expression)
   extends UnaryExpression with MagellanExpression {
 
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    val serializersVar = ctx.freshName("serializers")
-
-    ctx.addMutableState(classOf[java.util.HashMap[Integer, UserDefinedType[Shape]]].getName, s"$serializersVar",
-      s"$serializersVar = new java.util.HashMap<Integer, org.apache.spark.sql.types.UserDefinedType<magellan.Shape>>() ;" +
-        s"$serializersVar.put(1, new org.apache.spark.sql.types.PointUDT());" +
-        s"$serializersVar.put(2, new org.apache.spark.sql.types.LineUDT());" +
-        s"$serializersVar.put(3, new org.apache.spark.sql.types.PolyLineUDT());" +
-        s"$serializersVar.put(5, new org.apache.spark.sql.types.PolygonUDT());" +
+    val serializersVar = ctx.addMutableState(classOf[java.util.HashMap[Integer, UserDefinedType[Shape]]].getName, "serializers",
+      v => s"$v = new java.util.HashMap<Integer, org.apache.spark.sql.types.UserDefinedType<magellan.Shape>>() ;" +
+        s"$v.put(1, new org.apache.spark.sql.types.PointUDT());" +
+        s"$v.put(2, new org.apache.spark.sql.types.LineUDT());" +
+        s"$v.put(3, new org.apache.spark.sql.types.PolyLineUDT());" +
+        s"$v.put(5, new org.apache.spark.sql.types.PolygonUDT());" +
         "")
 
     val childTypeVar = ctx.freshName("childType")
@@ -201,14 +197,12 @@ case class Indexer(
     val indexSerializerVar = ctx.freshName("indexSerializer")
     val indexVar = ctx.freshName("v")
 
-    val serializersVar = ctx.freshName("serializers")
-
-    ctx.addMutableState(classOf[java.util.HashMap[Integer, UserDefinedType[Shape]]].getName, s"$serializersVar",
-      s"$serializersVar = new java.util.HashMap<Integer, org.apache.spark.sql.types.UserDefinedType<magellan.Shape>>() ;" +
-        s"$serializersVar.put(1, new org.apache.spark.sql.types.PointUDT());" +
-        s"$serializersVar.put(2, new org.apache.spark.sql.types.LineUDT());" +
-        s"$serializersVar.put(3, new org.apache.spark.sql.types.PolyLineUDT());" +
-        s"$serializersVar.put(5, new org.apache.spark.sql.types.PolygonUDT());" +
+    val serializersVar = ctx.addMutableState(classOf[java.util.HashMap[Integer, UserDefinedType[Shape]]].getName, "serializers",
+      v => s"$v = new java.util.HashMap<Integer, org.apache.spark.sql.types.UserDefinedType<magellan.Shape>>() ;" +
+        s"$v.put(1, new org.apache.spark.sql.types.PointUDT());" +
+        s"$v.put(2, new org.apache.spark.sql.types.LineUDT());" +
+        s"$v.put(3, new org.apache.spark.sql.types.PolyLineUDT());" +
+        s"$v.put(5, new org.apache.spark.sql.types.PolygonUDT());" +
         "")
 
     val idx = ctx.references.length
@@ -261,14 +255,12 @@ case class AsGeoJSON(override val child: Expression)
     val childShapeVar = ctx.freshName("childShape")
     val shapeSerializerVar = ctx.freshName("shapeSerializer")
     val resultVar = ctx.freshName("result")
-    val serializersVar = ctx.freshName("serializers")
-
-    ctx.addMutableState(classOf[java.util.HashMap[Integer, UserDefinedType[Shape]]].getName, s"$serializersVar",
-      s"$serializersVar = new java.util.HashMap<Integer, org.apache.spark.sql.types.UserDefinedType<magellan.Shape>>() ;" +
-        s"$serializersVar.put(1, new org.apache.spark.sql.types.PointUDT());" +
-        s"$serializersVar.put(2, new org.apache.spark.sql.types.LineUDT());" +
-        s"$serializersVar.put(3, new org.apache.spark.sql.types.PolyLineUDT());" +
-        s"$serializersVar.put(5, new org.apache.spark.sql.types.PolygonUDT());" +
+    val serializersVar = ctx.addMutableState(classOf[java.util.HashMap[Integer, UserDefinedType[Shape]]].getName, "serializers",
+      v => s"$v = new java.util.HashMap<Integer, org.apache.spark.sql.types.UserDefinedType<magellan.Shape>>() ;" +
+        s"$v.put(1, new org.apache.spark.sql.types.PointUDT());" +
+        s"$v.put(2, new org.apache.spark.sql.types.LineUDT());" +
+        s"$v.put(3, new org.apache.spark.sql.types.PolyLineUDT());" +
+        s"$v.put(5, new org.apache.spark.sql.types.PolygonUDT());" +
         "")
 
     nullSafeCodeGen(ctx, ev, (c1) => {
@@ -306,16 +298,15 @@ case class Buffer(override val child: Expression, distance: Double)
     val distanceVar = ctx.freshName("distance")
     val resultVar = ctx.freshName("result")
     val resultTypeVar = ctx.freshName("resultType")
-    val serializersVar = ctx.freshName("serializers")
     val idx = ctx.references.length
     ctx.addReferenceObj("distance", distance);
 
-    ctx.addMutableState(classOf[java.util.HashMap[Integer, UserDefinedType[Shape]]].getName, s"$serializersVar",
-      s"$serializersVar = new java.util.HashMap<Integer, org.apache.spark.sql.types.UserDefinedType<magellan.Shape>>() ;" +
-        s"$serializersVar.put(1, new org.apache.spark.sql.types.PointUDT());" +
-        s"$serializersVar.put(2, new org.apache.spark.sql.types.LineUDT());" +
-        s"$serializersVar.put(3, new org.apache.spark.sql.types.PolyLineUDT());" +
-        s"$serializersVar.put(5, new org.apache.spark.sql.types.PolygonUDT());" +
+    val serializersVar = ctx.addMutableState(classOf[java.util.HashMap[Integer, UserDefinedType[Shape]]].getName, "serializers",
+      v => s"$v = new java.util.HashMap<Integer, org.apache.spark.sql.types.UserDefinedType<magellan.Shape>>() ;" +
+        s"$v.put(1, new org.apache.spark.sql.types.PointUDT());" +
+        s"$v.put(2, new org.apache.spark.sql.types.LineUDT());" +
+        s"$v.put(3, new org.apache.spark.sql.types.PolyLineUDT());" +
+        s"$v.put(5, new org.apache.spark.sql.types.PolygonUDT());" +
         "")
 
     nullSafeCodeGen(ctx, ev, (c1) => {

--- a/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -64,14 +64,12 @@ case class Intersects(left: Expression, right: Expression)
   }
 
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    val serializersVar = ctx.freshName("serializers")
-
-    ctx.addMutableState(classOf[java.util.HashMap[Integer, UserDefinedType[Shape]]].getName, s"$serializersVar",
-      s"$serializersVar = new java.util.HashMap<Integer, org.apache.spark.sql.types.UserDefinedType<magellan.Shape>>() ;" +
-        s"$serializersVar.put(1, new org.apache.spark.sql.types.PointUDT());" +
-        s"$serializersVar.put(2, new org.apache.spark.sql.types.LineUDT());" +
-        s"$serializersVar.put(3, new org.apache.spark.sql.types.PolyLineUDT());" +
-        s"$serializersVar.put(5, new org.apache.spark.sql.types.PolygonUDT());" +
+    val serializersVar = ctx.addMutableState(classOf[java.util.HashMap[Integer, UserDefinedType[Shape]]].getName, "serializers",
+      v => s"$v = new java.util.HashMap<Integer, org.apache.spark.sql.types.UserDefinedType<magellan.Shape>>() ;" +
+        s"$v.put(1, new org.apache.spark.sql.types.PointUDT());" +
+        s"$v.put(2, new org.apache.spark.sql.types.LineUDT());" +
+        s"$v.put(3, new org.apache.spark.sql.types.PolyLineUDT());" +
+        s"$v.put(5, new org.apache.spark.sql.types.PolygonUDT());" +
         "")
 
     val lxminVar = ctx.freshName("lxmin")
@@ -155,14 +153,12 @@ case class Within(left: Expression, right: Expression)
   override def nullable: Boolean = left.nullable || right.nullable
 
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    val serializersVar = ctx.freshName("serializers")
-
-    ctx.addMutableState(classOf[java.util.HashMap[Integer, UserDefinedType[Shape]]].getName, s"$serializersVar",
-      s"$serializersVar = new java.util.HashMap<Integer, org.apache.spark.sql.types.UserDefinedType<magellan.Shape>>() ;" +
-        s"$serializersVar.put(1, new org.apache.spark.sql.types.PointUDT());" +
-        s"$serializersVar.put(2, new org.apache.spark.sql.types.LineUDT());" +
-        s"$serializersVar.put(3, new org.apache.spark.sql.types.PolyLineUDT());" +
-        s"$serializersVar.put(5, new org.apache.spark.sql.types.PolygonUDT());" +
+    val serializersVar = ctx.addMutableState(classOf[java.util.HashMap[Integer, UserDefinedType[Shape]]].getName, "serializers",
+      v => s"$v = new java.util.HashMap<Integer, org.apache.spark.sql.types.UserDefinedType<magellan.Shape>>() ;" +
+        s"$v.put(1, new org.apache.spark.sql.types.PointUDT());" +
+        s"$v.put(2, new org.apache.spark.sql.types.LineUDT());" +
+        s"$v.put(3, new org.apache.spark.sql.types.PolyLineUDT());" +
+        s"$v.put(5, new org.apache.spark.sql.types.PolygonUDT());" +
         "")
 
     val lxminVar = ctx.freshName("lxmin")

--- a/src/test/scala/magellan/catalyst/SpatialJoinSuite.scala
+++ b/src/test/scala/magellan/catalyst/SpatialJoinSuite.scala
@@ -158,14 +158,14 @@ class SpatialJoinSuite extends FunSuite with TestSparkContext {
     val ring = Array(Point(1.0, 1.0), Point(1.0, -1.0),
       Point(-1.0, -1.0), Point(-1.0, 1.0),
       Point(1.0, 1.0))
-    val polygons = sc.parallelize(Seq(
+    val polygons = Seq(
       ("1", Polygon(Array(0), ring))
-    )).toDF("id", "polygon")
+    ).toDF("id", "polygon")
 
-    val points = sc.parallelize(Seq(
+    val points =Seq(
       ("a", 1, Point(0.0, 0.0)),
       ("b" , 2, Point(2.0, 2.0))
-    )).toDF("name", "value", "point")
+    ).toDF("name", "value", "point")
 
     val joined = points.join(broadcast(polygons index 5)).where($"point" within $"polygon")
     assert(joined.queryExecution.executedPlan.toString() contains "BroadcastExchange")
@@ -186,10 +186,10 @@ class SpatialJoinSuite extends FunSuite with TestSparkContext {
 
     val cities = sc.parallelize(Seq(("San Francisco", Point(-122.5076401, 37.7576793)))).toDF("city", "point")
 
-    val results = cities.join(countries index 5).where($"point" within $"polygon").collect()(0)
+    val results = cities.join(countries index 5).where($"point" within $"polygon")
 
     //polygon, name, point, city
-    assert(results.length === 4)
+    assert(results.columns.size === 4)
   }
 
   test("Optimize Left Outer Join") {


### PR DESCRIPTION
This PR makes the changes necessary for Magellan to work with Spark 2.3.1 (#213).  All tests are passing and it has been run lightly in production and there are no obvious negative side effects of the upgrade.  

